### PR TITLE
[Feat/guardian] 보호자 홈/일정/설정 화면 및 2단계 로그인 연동

### DIFF
--- a/lib/core/constants/apis.dart
+++ b/lib/core/constants/apis.dart
@@ -15,6 +15,7 @@ abstract class Apis {
 
   /// 로그인 관련 api
   static const String postLogin = "api/auth/login";
+  static const String postLoginMode = "api/auth/login/mode";
   static const String getCheckId = "api/auth/check-id";
   static const String postPhoneVerify = "api/auth/phone/verify";
   static const String sendPhoneNumber = "api/auth/phone/send";

--- a/lib/core/constants/apis.dart
+++ b/lib/core/constants/apis.dart
@@ -13,6 +13,9 @@ abstract class Apis {
   /// 멤버 관련 api
   static const String fcmToken = "api/members/fcm-token";
 
+  /// 복약 관련 api
+  static const String getMedications = "api/medicine/medications";
+
   /// 로그인 관련 api
   static const String postLogin = "api/auth/login";
   static const String postLoginMode = "api/auth/login/mode";

--- a/lib/core/di/service_locator.dart
+++ b/lib/core/di/service_locator.dart
@@ -4,6 +4,7 @@ import 'package:ongi_app/data/repositories/secure_storage_repository.dart';
 import 'package:ongi_app/data/services/auth_service.dart';
 import 'package:ongi_app/data/services/auth_session.dart';
 import 'package:ongi_app/data/services/member_service.dart';
+import 'package:ongi_app/data/services/medicine_service.dart';
 
 final getIt = GetIt.instance;
 
@@ -26,5 +27,8 @@ void setupServiceLocator() {
       getIt<ApiClient>().dio,
       getIt<SecureStorageRepository>(),
     ),
+  );
+  getIt.registerLazySingleton<MedicineService>(
+    () => MedicineService(getIt<ApiClient>().dio),
   );
 }

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -12,6 +12,7 @@ import 'package:ongi_app/features/elder/elder_shell.dart';
 import 'package:ongi_app/features/elder/home/elder_home_screen.dart';
 import 'package:ongi_app/features/guardian/guardian_shell.dart';
 import 'package:ongi_app/features/guardian/home/guardian_home_screen.dart';
+import 'package:ongi_app/features/guardian/schedule/schedule_screen.dart';
 import 'routes.dart';
 
 final appRouter = GoRouter(
@@ -66,7 +67,7 @@ final appRouter = GoRouter(
         StatefulShellBranch(routes: [
           GoRoute(
             path: AppRoutes.guardianSchedule,
-            builder: (context, state) => const _PlaceholderScreen(label: '일정'),
+            builder: (context, state) => const GuardianScheduleScreen(),
           ),
         ]),
         StatefulShellBranch(routes: [

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -13,6 +13,7 @@ import 'package:ongi_app/features/elder/home/elder_home_screen.dart';
 import 'package:ongi_app/features/guardian/guardian_shell.dart';
 import 'package:ongi_app/features/guardian/home/guardian_home_screen.dart';
 import 'package:ongi_app/features/guardian/schedule/schedule_screen.dart';
+import 'package:ongi_app/features/guardian/setting/setting_screen.dart';
 import 'routes.dart';
 
 final appRouter = GoRouter(
@@ -73,7 +74,7 @@ final appRouter = GoRouter(
         StatefulShellBranch(routes: [
           GoRoute(
             path: AppRoutes.guardianSettings,
-            builder: (context, state) => const _PlaceholderScreen(label: '설정'),
+            builder: (context, state) => const GuardianSettingScreen(),
           ),
         ]),
       ],

--- a/lib/data/dto/request/login_request_dto.dart
+++ b/lib/data/dto/request/login_request_dto.dart
@@ -1,21 +1,18 @@
 class LoginRequestDto {
-  final String loginId;
-  final String password;
+  final String loginSessionToken;
   final String loginMode;
   final String fcmToken;
   final String osType;
 
   const LoginRequestDto({
-    required this.loginId,
-    required this.password,
+    required this.loginSessionToken,
     required this.loginMode,
     required this.fcmToken,
     required this.osType,
   });
 
   Map<String, dynamic> toJson() => {
-        'loginId': loginId,
-        'password': password,
+        'loginSessionToken': loginSessionToken,
         'loginMode': loginMode,
         'fcmToken': fcmToken,
         'osType': osType,

--- a/lib/data/dto/request/login_session_request_dto.dart
+++ b/lib/data/dto/request/login_session_request_dto.dart
@@ -1,0 +1,14 @@
+class LoginSessionRequestDto {
+  final String loginId;
+  final String password;
+
+  const LoginSessionRequestDto({
+    required this.loginId,
+    required this.password,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'loginId': loginId,
+        'password': password,
+      };
+}

--- a/lib/data/dto/response/login_response_dto.dart
+++ b/lib/data/dto/response/login_response_dto.dart
@@ -2,14 +2,14 @@ class LoginResponseDto {
   final String accessToken;
   final String refreshToken;
   final String loginMode;
-  final MemberResponseDto member;
-  final List<ElderResponseDto>? elder;
+  final MemberResponseDto? member;
+  final ElderResponseDto? elder;
 
   const LoginResponseDto({
     required this.accessToken,
     required this.refreshToken,
     required this.loginMode,
-    required this.member,
+    this.member,
     this.elder,
   });
 
@@ -18,11 +18,12 @@ class LoginResponseDto {
       accessToken: json['accessToken'] as String,
       refreshToken: json['refreshToken'] as String,
       loginMode: json['loginMode'] as String,
-      member:
-          MemberResponseDto.fromJson(json['member'] as Map<String, dynamic>),
-      elder: (json['elder'] as List<dynamic>?)
-          ?.map((e) => ElderResponseDto.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      member: json['member'] == null
+          ? null
+          : MemberResponseDto.fromJson(json['member'] as Map<String, dynamic>),
+      elder: json['elder'] == null
+          ? null
+          : ElderResponseDto.fromJson(json['elder'] as Map<String, dynamic>),
     );
   }
 }

--- a/lib/data/dto/response/login_session_response_dto.dart
+++ b/lib/data/dto/response/login_session_response_dto.dart
@@ -1,0 +1,13 @@
+class LoginSessionResponseDto {
+  final String loginSessionToken;
+
+  const LoginSessionResponseDto({
+    required this.loginSessionToken,
+  });
+
+  factory LoginSessionResponseDto.fromJson(Map<String, dynamic> json) {
+    return LoginSessionResponseDto(
+      loginSessionToken: json['loginSessionToken'] as String,
+    );
+  }
+}

--- a/lib/data/dto/response/medication_record_response_dto.dart
+++ b/lib/data/dto/response/medication_record_response_dto.dart
@@ -1,0 +1,27 @@
+class MedicationRecordResponseDto {
+  final int recordId;
+  final String medicineName;
+  final String scheduledTime;
+  final String result;
+  final DateTime? recordedAt;
+
+  const MedicationRecordResponseDto({
+    required this.recordId,
+    required this.medicineName,
+    required this.scheduledTime,
+    required this.result,
+    this.recordedAt,
+  });
+
+  factory MedicationRecordResponseDto.fromJson(Map<String, dynamic> json) {
+    return MedicationRecordResponseDto(
+      recordId: json['recordId'] as int,
+      medicineName: json['medicineName'] as String,
+      scheduledTime: json['scheduledTime'] as String,
+      result: json['result'] as String,
+      recordedAt: json['recordedAt'] == null
+          ? null
+          : DateTime.tryParse(json['recordedAt'] as String),
+    );
+  }
+}

--- a/lib/data/repositories/secure_storage_repository.dart
+++ b/lib/data/repositories/secure_storage_repository.dart
@@ -55,6 +55,14 @@ class SecureStorageRepository {
     return value != null ? int.tryParse(value) : null;
   }
 
+  Future<void> saveElderName(String name) async {
+    await _storage.write(key: 'elder_name', value: name);
+  }
+
+  Future<String?> readElderName() async {
+    return await _storage.read(key: 'elder_name');
+  }
+
   Future<String?> readFcmToken() async {
     return await _storage.read(key: 'fcm_token');
   }

--- a/lib/data/repositories/secure_storage_repository.dart
+++ b/lib/data/repositories/secure_storage_repository.dart
@@ -46,6 +46,15 @@ class SecureStorageRepository {
     return value != null ? int.tryParse(value) : null;
   }
 
+  Future<void> saveElderId(int elderId) async {
+    await _storage.write(key: 'elderId', value: elderId.toString());
+  }
+
+  Future<int?> getElderId() async {
+    final value = await _storage.read(key: 'elderId');
+    return value != null ? int.tryParse(value) : null;
+  }
+
   Future<String?> readFcmToken() async {
     return await _storage.read(key: 'fcm_token');
   }

--- a/lib/data/services/auth_service.dart
+++ b/lib/data/services/auth_service.dart
@@ -1,8 +1,10 @@
 import 'package:dio/dio.dart';
 import 'package:ongi_app/core/constants/apis.dart';
 import 'package:ongi_app/data/dto/request/login_request_dto.dart';
+import 'package:ongi_app/data/dto/request/login_session_request_dto.dart';
 import 'package:ongi_app/data/dto/request/signup_request_dto.dart';
 import 'package:ongi_app/data/dto/response/login_response_dto.dart';
+import 'package:ongi_app/data/dto/response/login_session_response_dto.dart';
 import 'package:ongi_app/data/network/api_exception.dart';
 import 'package:ongi_app/data/repositories/secure_storage_repository.dart';
 
@@ -12,10 +14,29 @@ class AuthService {
 
   AuthService(this._dio, this._secureStorage);
 
-  Future<LoginResponseDto> login(LoginRequestDto dto) async {
+  Future<LoginSessionResponseDto> createLoginSession(
+    LoginSessionRequestDto dto,
+  ) async {
     try {
       final response = await _dio.post(
         Apis.postLogin,
+        data: dto.toJson(),
+        options: Options(extra: {'skipAuthToken': true}),
+      );
+      final data = response.data['data'] as Map<String, dynamic>;
+      return LoginSessionResponseDto.fromJson(data);
+    } on DioException catch (e) {
+      throw ApiException(
+        e.response?.data?['message'] ?? '로그인에 실패했습니다.',
+        e.response?.statusCode,
+      );
+    }
+  }
+
+  Future<LoginResponseDto> login(LoginRequestDto dto) async {
+    try {
+      final response = await _dio.post(
+        Apis.postLoginMode,
         data: dto.toJson(),
         options: Options(extra: {'skipAuthToken': true}),
       );
@@ -25,8 +46,15 @@ class AuthService {
       await _secureStorage.saveAccessToken(result.accessToken);
       await _secureStorage.saveRefreshToken(result.refreshToken);
       await _secureStorage.saveRole(result.loginMode);
-      await _secureStorage.saveUserId(result.member.memberId);
-      await _secureStorage.saveUserName(result.member.name);
+      final member = result.member;
+      final elder = result.elder;
+      if (member != null) {
+        await _secureStorage.saveUserId(member.memberId);
+        await _secureStorage.saveUserName(member.name);
+      } else if (elder != null) {
+        await _secureStorage.saveUserId(elder.elderId);
+        await _secureStorage.saveUserName(elder.name);
+      }
 
       return result;
     } on DioException catch (e) {

--- a/lib/data/services/auth_service.dart
+++ b/lib/data/services/auth_service.dart
@@ -50,6 +50,7 @@ class AuthService {
       final elder = result.elder;
       if (elder != null) {
         await _secureStorage.saveElderId(elder.elderId);
+        await _secureStorage.saveElderName(elder.name);
       }
       if (member != null) {
         await _secureStorage.saveUserId(member.memberId);

--- a/lib/data/services/auth_service.dart
+++ b/lib/data/services/auth_service.dart
@@ -48,6 +48,9 @@ class AuthService {
       await _secureStorage.saveRole(result.loginMode);
       final member = result.member;
       final elder = result.elder;
+      if (elder != null) {
+        await _secureStorage.saveElderId(elder.elderId);
+      }
       if (member != null) {
         await _secureStorage.saveUserId(member.memberId);
         await _secureStorage.saveUserName(member.name);

--- a/lib/data/services/auth_session.dart
+++ b/lib/data/services/auth_session.dart
@@ -1,14 +1,20 @@
 class AuthSession {
   String? pendingLoginId;
   String? pendingPassword;
+  String? loginSessionToken;
 
   void set(String loginId, String password) {
     pendingLoginId = loginId;
     pendingPassword = password;
   }
 
+  void setLoginSessionToken(String token) {
+    loginSessionToken = token;
+  }
+
   void clear() {
     pendingLoginId = null;
     pendingPassword = null;
+    loginSessionToken = null;
   }
 }

--- a/lib/data/services/medicine_service.dart
+++ b/lib/data/services/medicine_service.dart
@@ -1,0 +1,35 @@
+import 'package:dio/dio.dart';
+import 'package:ongi_app/core/constants/apis.dart';
+import 'package:ongi_app/data/dto/response/medication_record_response_dto.dart';
+import 'package:ongi_app/data/network/api_exception.dart';
+
+class MedicineService {
+  final Dio _dio;
+
+  MedicineService(this._dio);
+
+  Future<List<MedicationRecordResponseDto>> getMedicationRecords({
+    required int elderId,
+    required String date,
+  }) async {
+    try {
+      final response = await _dio.get(
+        Apis.getMedications,
+        queryParameters: {
+          'elderId': elderId,
+          'date': date,
+        },
+      );
+      final data = response.data['data'] as List<dynamic>;
+      return data
+          .map((e) =>
+              MedicationRecordResponseDto.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw ApiException(
+        e.response?.data?['message'] ?? '복약 기록을 불러오지 못했습니다.',
+        e.response?.statusCode,
+      );
+    }
+  }
+}

--- a/lib/features/auth/login/login_view_model.dart
+++ b/lib/features/auth/login/login_view_model.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:ongi_app/core/di/service_locator.dart';
+import 'package:ongi_app/data/dto/request/login_session_request_dto.dart';
+import 'package:ongi_app/data/services/auth_service.dart';
 import 'package:ongi_app/data/services/auth_session.dart';
 
 class LoginViewModel extends ChangeNotifier {
+  final _authService = getIt<AuthService>();
   final _authSession = getIt<AuthSession>();
 
   final TextEditingController idController = TextEditingController();
@@ -32,7 +35,13 @@ class LoginViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
-      _authSession.set(idController.text.trim(), passwordController.text);
+      final result = await _authService.createLoginSession(
+        LoginSessionRequestDto(
+          loginId: idController.text.trim(),
+          password: passwordController.text,
+        ),
+      );
+      _authSession.setLoginSessionToken(result.loginSessionToken);
       onSuccess();
     } catch (e) {
       _errorMessage = '아이디 또는 비밀번호가 올바르지 않습니다.';

--- a/lib/features/auth/role_select/role_select_view_model.dart
+++ b/lib/features/auth/role_select/role_select_view_model.dart
@@ -33,9 +33,8 @@ class RoleSelectViewModel extends ChangeNotifier {
   }) async {
     if (_selectedRole == null) return;
 
-    final loginId = _authSession.pendingLoginId;
-    final password = _authSession.pendingPassword;
-    if (loginId == null || password == null) return;
+    final loginSessionToken = _authSession.loginSessionToken;
+    if (loginSessionToken == null) return;
 
     _isLoading = true;
     _errorMessage = null;
@@ -46,8 +45,7 @@ class RoleSelectViewModel extends ChangeNotifier {
       final osType = Platform.isIOS ? 'IOS' : 'ANDROID';
 
       await _authService.login(LoginRequestDto(
-        loginId: loginId,
-        password: password,
+        loginSessionToken: loginSessionToken,
         loginMode: _selectedRole!.name,
         fcmToken: fcmToken,
         osType: osType,

--- a/lib/features/guardian/home/guardian_home_header.dart
+++ b/lib/features/guardian/home/guardian_home_header.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:ongi_app/core/constants/constants.dart';
+
+class GuardianHomeHeader extends StatelessWidget {
+  const GuardianHomeHeader({
+    super.key,
+    required this.dateText,
+    required this.name,
+    required this.greeting,
+  });
+
+  final String dateText;
+  final String name;
+  final String greeting;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SvgPicture.asset(
+          'assets/logo.svg',
+          height: 28,
+        ),
+        const SizedBox(height: 16),
+        Text(dateText, style: OngiTextStyle.body15),
+        const SizedBox(height: 4),
+        RichText(
+          text: TextSpan(
+            style: const TextStyle(
+              fontSize: 20,
+              color: Colors.black,
+              height: 1.3,
+            ),
+            children: [
+              TextSpan(
+                text: '$name님',
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+              const TextSpan(text: '의 일정이에요'),
+            ],
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          greeting,
+          style: OngiTextStyle.body15.copyWith(
+            color: OngiColor.systemGray03,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/guardian/home/guardian_home_screen.dart
+++ b/lib/features/guardian/home/guardian_home_screen.dart
@@ -1,25 +1,183 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:ongi_app/core/constants/constants.dart';
+import 'package:ongi_app/core/constants/styles.dart';
 
 class GuardianHomeScreen extends StatelessWidget {
   const GuardianHomeScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    // 주황색 포인트 컬러 (사용하시는 브랜드 컬러가 있다면 바꿔주세요)
+    const primaryColor = Color(0xFFF27A35);
+    final todayText = _formatToday(DateTime.now());
+
     return Scaffold(
       backgroundColor: Colors.white,
       body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const SizedBox(height: 24),
-              Text('홈', style: OngiTextStyle.body15),
+              // 1. 상단 아이콘 및 날짜/타이틀 영역
+              SvgPicture.asset(
+                'assets/logo.svg',
+                height: 28,
+              ),
+              const SizedBox(height: 16),
+              Text(todayText, style: OngiTextStyle.body15),
+              const SizedBox(height: 4),
+              RichText(
+                text: const TextSpan(
+                  style:
+                      TextStyle(fontSize: 20, color: Colors.black, height: 1.3),
+                  children: [
+                    TextSpan(
+                      text: '홍길동님',
+                      style: OngiTextStyle.subTitle,
+                    ),
+                    TextSpan(text: '의 일정이에요'),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '오늘도 따뜻한 하루 보내세요',
+                style: OngiTextStyle.body15
+                    .copyWith(color: OngiColor.systemGray03),
+              ),
+              const SizedBox(height: 32),
+
+              // 2. 어르신 복용 체크 섹션
+              const Text(
+                '어르신 복용 체크',
+                style: OngiTextStyle.button18,
+              ),
+              const SizedBox(height: 12),
+              Container(
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(color: Colors.grey.shade200, width: 1.5),
+                ),
+                child: Column(
+                  children: [
+                    _buildMedicationTile('감기약', '08:30',
+                        isChecked: false, color: primaryColor),
+                    _buildDivider(),
+                    _buildMedicationTile('혈압약', '12:00',
+                        isChecked: true, color: primaryColor),
+                    _buildDivider(),
+                    _buildMedicationTile('비타민', '17:00',
+                        isChecked: true, color: primaryColor),
+                    _buildDivider(),
+                    _buildMedicationTile('감기약', '17:00',
+                        isChecked: false, color: primaryColor),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 32),
+
+              // 3. 디바이스 연결 체크 섹션
+              const Text(
+                '디바이스 연결 체크',
+                style: OngiTextStyle.button18,
+              ),
+              const SizedBox(height: 12),
+              Container(
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(color: Colors.grey.shade200, width: 1.5),
+                ),
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Column(
+                  children: [
+                    _buildDeviceStatusTile('디바이스 정상 작동', isNormal: true),
+                    _buildDeviceStatusTile('네트워크 정상 연결', isNormal: true),
+                  ],
+                ),
+              ),
             ],
           ),
         ),
       ),
+    );
+  }
+
+  // --- 위젯을 간결하게 유지하기 위한 컴포넌트 팩토리 메서드들 ---
+
+  String _formatToday(DateTime date) {
+    const weekdays = ['월', '화', '수', '목', '금', '토', '일'];
+    final year = date.year.toString();
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    final weekday = weekdays[date.weekday - 1];
+
+    return '$year. $month. $day($weekday)';
+  }
+
+  // 복약 체크 리스트 스타일 빌더
+  Widget _buildMedicationTile(String title, String time,
+      {required bool isChecked, required Color color}) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      child: Row(
+        children: [
+          Container(
+            width: 24,
+            height: 24,
+            decoration: BoxDecoration(
+              color: isChecked ? color : Colors.grey.shade200,
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: isChecked
+                ? const Icon(Icons.check, color: Colors.white, size: 16)
+                : null,
+          ),
+          const SizedBox(width: 16),
+          Text(title, style: OngiTextStyle.button18),
+          const Spacer(),
+          Text(
+            time,
+            style: OngiTextStyle.button18.copyWith(
+                color: isChecked ? Colors.black : Colors.grey.shade400),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // 디바이스 상태 리스트 스타일 빌더
+  Widget _buildDeviceStatusTile(String title, {required bool isNormal}) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(2),
+            decoration: const BoxDecoration(
+              color: Color(0xFF4CAF50), // 초록색 체크 배경
+              shape: BoxShape.circle,
+            ),
+            child: const Icon(Icons.check, color: Colors.white, size: 16),
+          ),
+          const SizedBox(width: 16),
+          Text(title, style: OngiTextStyle.button18),
+        ],
+      ),
+    );
+  }
+
+  // 구분선 생성기 (리스트 아이템 사이 여백조절)
+  Widget _buildDivider() {
+    return Divider(
+      height: 1,
+      thickness: 1,
+      color: Colors.grey.shade100,
+      indent: 16,
+      endIndent: 16,
     );
   }
 }

--- a/lib/features/guardian/home/guardian_home_screen.dart
+++ b/lib/features/guardian/home/guardian_home_screen.dart
@@ -11,7 +11,7 @@ class GuardianHomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
-      create: (_) => GuardianHomeViewModel(),
+      create: (_) => GuardianHomeViewModel()..loadMedications(),
       child: const _GuardianHomeView(),
     );
   }
@@ -75,12 +75,7 @@ class _GuardianHomeView extends StatelessWidget {
                   borderRadius: BorderRadius.circular(16),
                   border: Border.all(color: Colors.grey.shade200, width: 1.5),
                 ),
-                child: Column(
-                  children: _buildSeparatedMedicationTiles(
-                    vm.medications,
-                    primaryColor,
-                  ),
-                ),
+                child: _buildMedicationSectionContent(vm, primaryColor),
               ),
               const SizedBox(height: 32),
 
@@ -114,6 +109,55 @@ class _GuardianHomeView extends StatelessWidget {
   }
 
   // --- 위젯을 간결하게 유지하기 위한 컴포넌트 팩토리 메서드들 ---
+
+  Widget _buildMedicationSectionContent(
+    GuardianHomeViewModel vm,
+    Color primaryColor,
+  ) {
+    if (vm.isMedicationLoading) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 24),
+        child: Center(
+          child: Text('복약 기록을 불러오는 중이에요', style: OngiTextStyle.body15),
+        ),
+      );
+    }
+
+    if (vm.medicationErrorMessage != null) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
+        child: Center(
+          child: Text(
+            vm.medicationErrorMessage!,
+            style: OngiTextStyle.body15.copyWith(
+              color: OngiColor.systemGray03,
+            ),
+          ),
+        ),
+      );
+    }
+
+    if (vm.medications.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 24),
+        child: Center(
+          child: Text(
+            '오늘 등록된 복약 기록이 없어요',
+            style: OngiTextStyle.body15.copyWith(
+              color: OngiColor.systemGray03,
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Column(
+      children: _buildSeparatedMedicationTiles(
+        vm.medications,
+        primaryColor,
+      ),
+    );
+  }
 
   List<Widget> _buildSeparatedMedicationTiles(
     List<MedicationItem> items,

--- a/lib/features/guardian/home/guardian_home_screen.dart
+++ b/lib/features/guardian/home/guardian_home_screen.dart
@@ -1,16 +1,30 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:ongi_app/core/constants/constants.dart';
-import 'package:ongi_app/core/constants/styles.dart';
+import 'package:provider/provider.dart';
+
+import 'guardian_home_view_model.dart';
 
 class GuardianHomeScreen extends StatelessWidget {
   const GuardianHomeScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => GuardianHomeViewModel(),
+      child: const _GuardianHomeView(),
+    );
+  }
+}
+
+class _GuardianHomeView extends StatelessWidget {
+  const _GuardianHomeView();
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<GuardianHomeViewModel>();
     // 주황색 포인트 컬러 (사용하시는 브랜드 컬러가 있다면 바꿔주세요)
     const primaryColor = Color(0xFFF27A35);
-    final todayText = _formatToday(DateTime.now());
 
     return Scaffold(
       backgroundColor: Colors.white,
@@ -26,24 +40,24 @@ class GuardianHomeScreen extends StatelessWidget {
                 height: 28,
               ),
               const SizedBox(height: 16),
-              Text(todayText, style: OngiTextStyle.body15),
+              Text(vm.todayText, style: OngiTextStyle.body15),
               const SizedBox(height: 4),
               RichText(
-                text: const TextSpan(
-                  style:
-                      TextStyle(fontSize: 20, color: Colors.black, height: 1.3),
+                text: TextSpan(
+                  style: const TextStyle(
+                      fontSize: 20, color: Colors.black, height: 1.3),
                   children: [
                     TextSpan(
-                      text: '홍길동님',
-                      style: OngiTextStyle.subTitle,
+                      text: '${vm.memberName}님',
+                      style: const TextStyle(fontWeight: FontWeight.bold),
                     ),
-                    TextSpan(text: '의 일정이에요'),
+                    const TextSpan(text: '의 일정이에요'),
                   ],
                 ),
               ),
               const SizedBox(height: 4),
               Text(
-                '오늘도 따뜻한 하루 보내세요',
+                vm.greeting,
                 style: OngiTextStyle.body15
                     .copyWith(color: OngiColor.systemGray03),
               ),
@@ -62,19 +76,10 @@ class GuardianHomeScreen extends StatelessWidget {
                   border: Border.all(color: Colors.grey.shade200, width: 1.5),
                 ),
                 child: Column(
-                  children: [
-                    _buildMedicationTile('감기약', '08:30',
-                        isChecked: false, color: primaryColor),
-                    _buildDivider(),
-                    _buildMedicationTile('혈압약', '12:00',
-                        isChecked: true, color: primaryColor),
-                    _buildDivider(),
-                    _buildMedicationTile('비타민', '17:00',
-                        isChecked: true, color: primaryColor),
-                    _buildDivider(),
-                    _buildMedicationTile('감기약', '17:00',
-                        isChecked: false, color: primaryColor),
-                  ],
+                  children: _buildSeparatedMedicationTiles(
+                    vm.medications,
+                    primaryColor,
+                  ),
                 ),
               ),
               const SizedBox(height: 32),
@@ -93,10 +98,12 @@ class GuardianHomeScreen extends StatelessWidget {
                 ),
                 padding: const EdgeInsets.symmetric(vertical: 8),
                 child: Column(
-                  children: [
-                    _buildDeviceStatusTile('디바이스 정상 작동', isNormal: true),
-                    _buildDeviceStatusTile('네트워크 정상 연결', isNormal: true),
-                  ],
+                  children: vm.deviceStatuses
+                      .map((item) => _buildDeviceStatusTile(
+                            item.title,
+                            isNormal: item.isNormal,
+                          ))
+                      .toList(),
                 ),
               ),
             ],
@@ -108,14 +115,21 @@ class GuardianHomeScreen extends StatelessWidget {
 
   // --- 위젯을 간결하게 유지하기 위한 컴포넌트 팩토리 메서드들 ---
 
-  String _formatToday(DateTime date) {
-    const weekdays = ['월', '화', '수', '목', '금', '토', '일'];
-    final year = date.year.toString();
-    final month = date.month.toString().padLeft(2, '0');
-    final day = date.day.toString().padLeft(2, '0');
-    final weekday = weekdays[date.weekday - 1];
-
-    return '$year. $month. $day($weekday)';
+  List<Widget> _buildSeparatedMedicationTiles(
+    List<MedicationItem> items,
+    Color primaryColor,
+  ) {
+    return [
+      for (var i = 0; i < items.length; i++) ...[
+        _buildMedicationTile(
+          items[i].title,
+          items[i].time,
+          isChecked: items[i].isChecked,
+          color: primaryColor,
+        ),
+        if (i < items.length - 1) _buildDivider(),
+      ],
+    ];
   }
 
   // 복약 체크 리스트 스타일 빌더

--- a/lib/features/guardian/home/guardian_home_screen.dart
+++ b/lib/features/guardian/home/guardian_home_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:ongi_app/core/constants/constants.dart';
 import 'package:provider/provider.dart';
 
+import 'guardian_home_header.dart';
 import 'guardian_home_view_model.dart';
 
 class GuardianHomeScreen extends StatelessWidget {
@@ -35,31 +35,10 @@ class _GuardianHomeView extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               // 1. 상단 아이콘 및 날짜/타이틀 영역
-              SvgPicture.asset(
-                'assets/logo.svg',
-                height: 28,
-              ),
-              const SizedBox(height: 16),
-              Text(vm.todayText, style: OngiTextStyle.body15),
-              const SizedBox(height: 4),
-              RichText(
-                text: TextSpan(
-                  style: const TextStyle(
-                      fontSize: 20, color: Colors.black, height: 1.3),
-                  children: [
-                    TextSpan(
-                      text: '${vm.memberName}님',
-                      style: const TextStyle(fontWeight: FontWeight.bold),
-                    ),
-                    const TextSpan(text: '의 일정이에요'),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 4),
-              Text(
-                vm.greeting,
-                style: OngiTextStyle.body15
-                    .copyWith(color: OngiColor.systemGray03),
+              GuardianHomeHeader(
+                dateText: vm.todayText,
+                name: vm.memberName,
+                greeting: vm.greeting,
               ),
               const SizedBox(height: 32),
 

--- a/lib/features/guardian/home/guardian_home_view_model.dart
+++ b/lib/features/guardian/home/guardian_home_view_model.dart
@@ -13,10 +13,11 @@ class GuardianHomeViewModel extends ChangeNotifier {
 
   bool _isMedicationLoading = false;
   String? _medicationErrorMessage;
+  String _elderName = '어르신';
 
   String get todayText => _formatDate(_today);
   String get queryDate => _formatQueryDate(_today);
-  String get memberName => '홍길동';
+  String get memberName => _elderName;
   String get greeting => '오늘도 따뜻한 하루 보내세요';
   bool get isMedicationLoading => _isMedicationLoading;
   String? get medicationErrorMessage => _medicationErrorMessage;
@@ -34,6 +35,11 @@ class GuardianHomeViewModel extends ChangeNotifier {
 
     try {
       final elderId = await _storage.getElderId();
+      final elderName = await _storage.readElderName();
+      if (elderName != null && elderName.isNotEmpty) {
+        _elderName = elderName;
+      }
+
       if (elderId == null) {
         _medications.clear();
         _medicationErrorMessage = '어르신 정보를 찾을 수 없습니다.';

--- a/lib/features/guardian/home/guardian_home_view_model.dart
+++ b/lib/features/guardian/home/guardian_home_view_model.dart
@@ -1,25 +1,67 @@
 import 'package:flutter/material.dart';
+import 'package:ongi_app/core/di/service_locator.dart';
+import 'package:ongi_app/data/repositories/secure_storage_repository.dart';
+import 'package:ongi_app/data/services/medicine_service.dart';
 
 class GuardianHomeViewModel extends ChangeNotifier {
   GuardianHomeViewModel({DateTime? now}) : _today = now ?? DateTime.now();
 
+  final _medicineService = getIt<MedicineService>();
+  final _storage = getIt<SecureStorageRepository>();
   final DateTime _today;
+  final List<MedicationItem> _medications = [];
+
+  bool _isMedicationLoading = false;
+  String? _medicationErrorMessage;
 
   String get todayText => _formatDate(_today);
+  String get queryDate => _formatQueryDate(_today);
   String get memberName => '홍길동';
   String get greeting => '오늘도 따뜻한 하루 보내세요';
-
-  List<MedicationItem> get medications => const [
-        MedicationItem(title: '감기약', time: '08:30', isChecked: false),
-        MedicationItem(title: '혈압약', time: '12:00', isChecked: true),
-        MedicationItem(title: '비타민', time: '17:00', isChecked: true),
-        MedicationItem(title: '감기약', time: '17:00', isChecked: false),
-      ];
+  bool get isMedicationLoading => _isMedicationLoading;
+  String? get medicationErrorMessage => _medicationErrorMessage;
+  List<MedicationItem> get medications => List.unmodifiable(_medications);
 
   List<DeviceStatusItem> get deviceStatuses => const [
         DeviceStatusItem(title: '디바이스 정상 작동', isNormal: true),
         DeviceStatusItem(title: '네트워크 정상 연결', isNormal: true),
       ];
+
+  Future<void> loadMedications() async {
+    _isMedicationLoading = true;
+    _medicationErrorMessage = null;
+    notifyListeners();
+
+    try {
+      final elderId = await _storage.getElderId();
+      if (elderId == null) {
+        _medications.clear();
+        _medicationErrorMessage = '어르신 정보를 찾을 수 없습니다.';
+        return;
+      }
+
+      final records = await _medicineService.getMedicationRecords(
+        elderId: elderId,
+        date: queryDate,
+      );
+
+      _medications
+        ..clear()
+        ..addAll(records.map(
+          (record) => MedicationItem(
+            title: record.medicineName,
+            time: _formatScheduledTime(record.scheduledTime),
+            isChecked: record.result == 'TAKEN',
+          ),
+        ));
+    } catch (e) {
+      _medications.clear();
+      _medicationErrorMessage = '복약 기록을 불러오지 못했습니다.';
+    } finally {
+      _isMedicationLoading = false;
+      notifyListeners();
+    }
+  }
 
   String _formatDate(DateTime date) {
     const weekdays = ['월', '화', '수', '목', '금', '토', '일'];
@@ -29,6 +71,20 @@ class GuardianHomeViewModel extends ChangeNotifier {
     final weekday = weekdays[date.weekday - 1];
 
     return '$year. $month. $day($weekday)';
+  }
+
+  String _formatQueryDate(DateTime date) {
+    final year = date.year.toString();
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+
+    return '$year-$month-$day';
+  }
+
+  String _formatScheduledTime(String scheduledTime) {
+    final parts = scheduledTime.split(':');
+    if (parts.length < 2) return scheduledTime;
+    return '${parts[0]}:${parts[1]}';
   }
 }
 

--- a/lib/features/guardian/home/guardian_home_view_model.dart
+++ b/lib/features/guardian/home/guardian_home_view_model.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+class GuardianHomeViewModel extends ChangeNotifier {
+  GuardianHomeViewModel({DateTime? now}) : _today = now ?? DateTime.now();
+
+  final DateTime _today;
+
+  String get todayText => _formatDate(_today);
+  String get memberName => '홍길동';
+  String get greeting => '오늘도 따뜻한 하루 보내세요';
+
+  List<MedicationItem> get medications => const [
+        MedicationItem(title: '감기약', time: '08:30', isChecked: false),
+        MedicationItem(title: '혈압약', time: '12:00', isChecked: true),
+        MedicationItem(title: '비타민', time: '17:00', isChecked: true),
+        MedicationItem(title: '감기약', time: '17:00', isChecked: false),
+      ];
+
+  List<DeviceStatusItem> get deviceStatuses => const [
+        DeviceStatusItem(title: '디바이스 정상 작동', isNormal: true),
+        DeviceStatusItem(title: '네트워크 정상 연결', isNormal: true),
+      ];
+
+  String _formatDate(DateTime date) {
+    const weekdays = ['월', '화', '수', '목', '금', '토', '일'];
+    final year = date.year.toString();
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    final weekday = weekdays[date.weekday - 1];
+
+    return '$year. $month. $day($weekday)';
+  }
+}
+
+class MedicationItem {
+  final String title;
+  final String time;
+  final bool isChecked;
+
+  const MedicationItem({
+    required this.title,
+    required this.time,
+    required this.isChecked,
+  });
+}
+
+class DeviceStatusItem {
+  final String title;
+  final bool isNormal;
+
+  const DeviceStatusItem({
+    required this.title,
+    required this.isNormal,
+  });
+}

--- a/lib/features/guardian/schedule/schedule_screen.dart
+++ b/lib/features/guardian/schedule/schedule_screen.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+import 'package:ongi_app/core/constants/styles.dart';
+import 'package:ongi_app/features/guardian/home/guardian_home_header.dart';
+import 'package:ongi_app/features/guardian/schedule/schedule_view_model.dart';
+import 'package:ongi_app/shared/widgets/basic_button.dart';
+
+class GuardianScheduleScreen extends StatefulWidget {
+  const GuardianScheduleScreen({super.key});
+
+  @override
+  State<GuardianScheduleScreen> createState() => _GuardianScheduleScreenState();
+}
+
+class _GuardianScheduleScreenState extends State<GuardianScheduleScreen> {
+  // 뷰모델 생성
+  final ScheduleViewModel _viewModel = ScheduleViewModel();
+
+  @override
+  void initState() {
+    super.initState();
+    _viewModel.loadHeaderData();
+  }
+
+  @override
+  void dispose() {
+    _viewModel.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const primaryColor = Color(0xFFF27A35);
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: ListenableBuilder(
+          listenable: _viewModel,
+          builder: (context, _) {
+            return Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SizedBox(height: 20),
+                  // 1. 상단 타이틀 영역
+                  GuardianHomeHeader(
+                    dateText: _viewModel.todayText,
+                    name: _viewModel.memberName,
+                    greeting: _viewModel.greeting,
+                  ),
+                  const SizedBox(height: 32),
+
+                  // 2. '약' 타이틀 및 '추가하기' 버튼 영역
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        '약',
+                        style: OngiTextStyle.subTitle
+                            .copyWith(color: primaryColor),
+                      ),
+                      GestureDetector(
+                        onTap: () {
+                          // 테스트용 데이터 추가 예시 (실제로는 다이얼로그나 새 창을 띄우시면 됩니다)
+                          _viewModel.addMedication('비타민', '13:00');
+                        },
+                        child: Row(
+                          children: [
+                            Text(
+                              '추가하기',
+                              style: OngiTextStyle.subTitle
+                                  .copyWith(color: primaryColor),
+                            ),
+                            const SizedBox(width: 4),
+                            const Icon(Icons.add_circle,
+                                color: primaryColor, size: 20),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+
+                  // 3. 약 목록 리스트 영역
+                  Expanded(
+                    child: _viewModel.medications.isEmpty
+                        ? const Center(child: Text('등록된 약 일정이 없습니다.'))
+                        : ListView.separated(
+                            itemCount: _viewModel.medications.length,
+                            separatorBuilder: (context, index) =>
+                                const SizedBox(height: 12),
+                            itemBuilder: (context, index) {
+                              final medication = _viewModel.medications[index];
+                              return _buildMedicationCard(
+                                index: index + 1,
+                                medication: medication,
+                                onDelete: () =>
+                                    _viewModel.removeMedication(medication.id),
+                              );
+                            },
+                          ),
+                  ),
+
+                  // 4. 하단 '약통 열기' 버튼
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 24),
+                    child: BasicButton(
+                      text: '약통 열기',
+                      isClickable: true,
+                      onPressed: () => _viewModel.openPillBox(),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  // 약 리스트의 단일 아이템 카드 빌더
+  Widget _buildMedicationCard({
+    required int index,
+    required MedicationModel medication,
+    required VoidCallback onDelete,
+  }) {
+    return Container(
+      height: 56,
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: Colors.grey.shade200, width: 1.5),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: Row(
+        children: [
+          // 번호 (예: 1.)
+          Text(
+            '$index.',
+            style: const TextStyle(
+                fontSize: 16, fontWeight: FontWeight.bold, color: Colors.black),
+          ),
+          const SizedBox(width: 16),
+          // 약 이름
+          Text(
+            medication.name,
+            style: const TextStyle(
+                fontSize: 16, fontWeight: FontWeight.bold, color: Colors.black),
+          ),
+          const Spacer(),
+          // 시간
+          Text(
+            medication.time,
+            style: const TextStyle(
+                fontSize: 18, fontWeight: FontWeight.bold, color: Colors.black),
+          ),
+          const SizedBox(width: 24),
+          // 삭제 버튼
+          GestureDetector(
+            onTap: onDelete,
+            child: const Text(
+              '삭제',
+              style: TextStyle(
+                  fontSize: 14,
+                  color: Colors.grey,
+                  fontWeight: FontWeight.w500),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/guardian/schedule/schedule_screen.dart
+++ b/lib/features/guardian/schedule/schedule_screen.dart
@@ -3,6 +3,7 @@ import 'package:ongi_app/core/constants/styles.dart';
 import 'package:ongi_app/features/guardian/home/guardian_home_header.dart';
 import 'package:ongi_app/features/guardian/schedule/schedule_view_model.dart';
 import 'package:ongi_app/shared/widgets/basic_button.dart';
+import 'package:ongi_app/shared/widgets/basic_text_field.dart';
 
 class GuardianScheduleScreen extends StatefulWidget {
   const GuardianScheduleScreen({super.key});
@@ -61,10 +62,7 @@ class _GuardianScheduleScreenState extends State<GuardianScheduleScreen> {
                             .copyWith(color: primaryColor),
                       ),
                       GestureDetector(
-                        onTap: () {
-                          // 테스트용 데이터 추가 예시 (실제로는 다이얼로그나 새 창을 띄우시면 됩니다)
-                          _viewModel.addMedication('비타민', '13:00');
-                        },
+                        onTap: _showAddMedicationDialog,
                         child: Row(
                           children: [
                             Text(
@@ -120,6 +118,16 @@ class _GuardianScheduleScreenState extends State<GuardianScheduleScreen> {
     );
   }
 
+  Future<void> _showAddMedicationDialog() async {
+    final medication = await showDialog<_MedicationInput>(
+      context: context,
+      builder: (_) => const _AddMedicationDialog(),
+    );
+
+    if (medication == null) return;
+    _viewModel.addMedication(medication.name, medication.time);
+  }
+
   // 약 리스트의 단일 아이템 카드 빌더
   Widget _buildMedicationCard({
     required int index,
@@ -172,4 +180,104 @@ class _GuardianScheduleScreenState extends State<GuardianScheduleScreen> {
       ),
     );
   }
+}
+
+class _AddMedicationDialog extends StatefulWidget {
+  const _AddMedicationDialog();
+
+  @override
+  State<_AddMedicationDialog> createState() => _AddMedicationDialogState();
+}
+
+class _AddMedicationDialogState extends State<_AddMedicationDialog> {
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _timeController = TextEditingController();
+
+  bool get _canAdd =>
+      _nameController.text.trim().isNotEmpty &&
+      _timeController.text.trim().isNotEmpty;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _timeController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final keyboardHeight = MediaQuery.viewInsetsOf(context).bottom;
+
+    return AnimatedPadding(
+      duration: const Duration(milliseconds: 180),
+      curve: Curves.easeOut,
+      padding: EdgeInsets.only(bottom: keyboardHeight),
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(
+              maxWidth: 360,
+              maxHeight: 420,
+            ),
+            child: Material(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(20),
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(20),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('약 추가하기', style: OngiTextStyle.button18),
+                    const SizedBox(height: 20),
+                    BasicTextField(
+                      label: '약 이름',
+                      hintText: '약 이름을 입력해주세요.',
+                      controller: _nameController,
+                      keyboardType: TextInputType.text,
+                      onChanged: (_) => setState(() {}),
+                    ),
+                    const SizedBox(height: 16),
+                    BasicTextField(
+                      label: '복용 시간',
+                      hintText: '예: 09:00',
+                      controller: _timeController,
+                      keyboardType: TextInputType.datetime,
+                      onChanged: (_) => setState(() {}),
+                    ),
+                    const SizedBox(height: 24),
+                    BasicButton(
+                      text: '추가하기',
+                      isClickable: _canAdd,
+                      onPressed: _canAdd
+                          ? () {
+                              Navigator.of(context).pop(
+                                _MedicationInput(
+                                  name: _nameController.text.trim(),
+                                  time: _timeController.text.trim(),
+                                ),
+                              );
+                            }
+                          : null,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MedicationInput {
+  const _MedicationInput({
+    required this.name,
+    required this.time,
+  });
+
+  final String name;
+  final String time;
 }

--- a/lib/features/guardian/schedule/schedule_view_model.dart
+++ b/lib/features/guardian/schedule/schedule_view_model.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:ongi_app/core/di/service_locator.dart';
+import 'package:ongi_app/data/repositories/secure_storage_repository.dart';
+
+// 약 데이터 모델
+class MedicationModel {
+  final String id;
+  final String name;
+  final String time;
+
+  MedicationModel({
+    required this.id,
+    required this.name,
+    required this.time,
+  });
+}
+
+// 일정 화면 뷰모델
+class ScheduleViewModel extends ChangeNotifier {
+  final _storage = getIt<SecureStorageRepository>();
+  final DateTime _today = DateTime.now();
+  String _elderName = '어르신';
+
+  // 샘플 데이터 (이미지 기준: 1. 혈압약 09:00)
+  final List<MedicationModel> _medications = [
+    MedicationModel(id: '1', name: '혈압약', time: '09:00'),
+  ];
+
+  String get todayText => _formatDate(_today);
+  String get memberName => _elderName;
+  String get greeting => '오늘도 따뜻한 하루 보내세요';
+  List<MedicationModel> get medications => _medications;
+
+  Future<void> loadHeaderData() async {
+    final elderName = await _storage.readElderName();
+    if (elderName != null && elderName.isNotEmpty) {
+      _elderName = elderName;
+      notifyListeners();
+    }
+  }
+
+  // 약 추가 기능 (추가하기 버튼 클릭 시)
+  void addMedication(String name, String time) {
+    final newId = (DateTime.now().millisecondsSinceEpoch).toString();
+    _medications.add(MedicationModel(id: newId, name: name, time: time));
+    notifyListeners(); // UI 업데이트 알림
+  }
+
+  // 약 삭제 기능 (삭제 텍스트 버튼 클릭 시)
+  void removeMedication(String id) {
+    _medications.removeWhere((med) => med.id == id);
+    notifyListeners(); // UI 업데이트 알림
+  }
+
+  // 약통 열기 버튼 기능
+  void openPillBox() {
+    // TODO: 하드웨어 디바이스 연동 또는 API 호출 로직
+    debugPrint('약통 열기 명령 전송');
+  }
+
+  String _formatDate(DateTime date) {
+    const weekdays = ['월', '화', '수', '목', '금', '토', '일'];
+    final year = date.year.toString();
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    final weekday = weekdays[date.weekday - 1];
+
+    return '$year. $month. $day($weekday)';
+  }
+}

--- a/lib/features/guardian/setting/setting_screen.dart
+++ b/lib/features/guardian/setting/setting_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:ongi_app/core/constants/constants.dart';
+import 'package:ongi_app/features/guardian/setting/setting_view_model.dart';
+
+class GuardianSettingScreen extends StatelessWidget {
+  const GuardianSettingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = SettingViewModel();
+    final menuItems = viewModel.getMenuItems(context);
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(height: 20),
+              // 상단 로고 및 타이틀
+              SvgPicture.asset(
+                'assets/logo.svg',
+                height: 28,
+              ),
+              const SizedBox(height: 24),
+              const Text(
+                '설정',
+                style: OngiTextStyle.subTitle,
+              ),
+              const SizedBox(height: 32),
+
+              // 설정 메뉴 리스트
+              Expanded(
+                child: ListView.separated(
+                  physics:
+                      const NeverScrollableScrollPhysics(), // 리스트가 짧으므로 스크롤 고정
+                  itemCount: menuItems.length,
+                  separatorBuilder: (context, index) =>
+                      const SizedBox(height: 8),
+                  itemBuilder: (context, index) {
+                    final item = menuItems[index];
+                    return _buildSettingTile(item);
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSettingTile(SettingMenuItem item) {
+    return InkWell(
+      onTap: item.onTap,
+      child: Container(
+        height: 50,
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              item.title,
+              style: OngiTextStyle.body15,
+            ),
+            const Icon(Icons.chevron_right_rounded,
+                color: Colors.black, size: 24),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/guardian/setting/setting_view_model.dart
+++ b/lib/features/guardian/setting/setting_view_model.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+// 설정 메뉴 아이템 모델
+class SettingMenuItem {
+  final String title;
+  final VoidCallback onTap;
+
+  SettingMenuItem({required this.title, required this.onTap});
+}
+
+class SettingViewModel extends ChangeNotifier {
+  // 메뉴 리스트 정의
+  List<SettingMenuItem> getMenuItems(BuildContext context) {
+    return [
+      SettingMenuItem(
+        title: '서비스이용약관',
+        onTap: () => debugPrint('서비스이용약관 이동'),
+      ),
+      SettingMenuItem(
+        title: '개인정보처리방침',
+        onTap: () => debugPrint('개인정보처리방침 이동'),
+      ),
+      SettingMenuItem(
+        title: '사용방법',
+        onTap: () => debugPrint('사용방법 이동'),
+      ),
+      SettingMenuItem(
+        title: '디바이스 연결',
+        onTap: () => debugPrint('디바이스 연결 이동'),
+      ),
+      SettingMenuItem(
+        title: '로그아웃',
+        onTap: () => _showWithdrawalDialog(context),
+      ),
+      SettingMenuItem(
+        title: '회원탈퇴',
+        onTap: () => _showWithdrawalDialog(context),
+      ),
+    ];
+  }
+
+  // 회원탈퇴 다이얼로그 예시
+  void _showWithdrawalDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('회원탈퇴'),
+        content: const Text('정말로 탈퇴하시겠습니까? 모든 정보가 삭제됩니다.'),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(context), child: const Text('취소')),
+          TextButton(
+            onPressed: () {
+              debugPrint('탈퇴 처리 진행');
+              Navigator.pop(context);
+            },
+            child: const Text('탈퇴', style: TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/guardian/setting/setting_view_model.dart
+++ b/lib/features/guardian/setting/setting_view_model.dart
@@ -40,6 +40,27 @@ class SettingViewModel extends ChangeNotifier {
   }
 
   // 회원탈퇴 다이얼로그 예시
+  void _showLogoutDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('로그아웃'),
+        content: const Text('정말로 로그아웃 하시겠습니까?'),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(context), child: const Text('취소')),
+          TextButton(
+            onPressed: () {
+              debugPrint('로그아웃');
+              Navigator.pop(context);
+            },
+            child: const Text('로그아웃', style: TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+  }
+
   void _showWithdrawalDialog(BuildContext context) {
     showDialog(
       context: context,


### PR DESCRIPTION
## Issue

- Resolves #13 

## Description
<!-- 어떤 기능을 구현했나요?    
기존 기능에서 어떤 점이 달라졌나요?  
자세한 로직이 필요하다면 함께 적어주세요!  
코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!   -->
 ### 작업 내용
  - 로그인 플로우를 2단계로 분리했습니다.
    - `/api/auth/login`에서 로그인 세션 토큰 발급
    - `/api/auth/login/mode`에서 역할 선택 후 JWT 발급
  - 로그인 응답에서 받은 어르신 ID와 이름을 Secure Storage에 저장하도록 추가했습니다.
  - 보호자 홈 화면을 MVVM 구조로 분리했습니다.
    - 공통 상단 헤더 위젯 추가
    - 오늘 날짜 표시
    - 저장된 어르신 이름 표시
  - 보호자 홈의 복약 체크 섹션을 서버 데이터 기반으로 변경했습니다.
    - `/api/medicine/medications`
    - `elderId`, `date` query 사용
    - `TAKEN` 여부에 따라 체크 상태 표시
  - 보호자 일정 화면을 추가했습니다.
    - 약 일정 목록 표시
    - 약 추가 다이얼로그 구현
    - `BasicTextField`, `BasicButton` 적용
    - 키보드 노출 시 다이얼로그 위치 조정
  - 보호자 설정 화면을 추가하고 라우터에 연결했습니다.
    - 설정 메뉴 목록 표시
    - 로그아웃/회원탈퇴 다이얼로그 추가
  - 보호자 탭 라우팅을 실제 화면으로 연결했습니다.
    - 홈 / 일정 / 설정
### TODO
일정 탭에서 약 추가하기와 약통열기 추가 구현 필요

  ## 테스트
  - `dart format` 실행 완료
  - `flutter analyze` 실행 완료
    - 신규 에러 없음
    - 기존 info만 남아 있음
      - `user_role.dart` enum 네이밍
      - `elder_home_screen.dart` const 관련 lint


## Screenshot
<!--기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요  -->

## 💬 리뷰 요구사항(선택)
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
 고민사항도 적어주세요.  -->
