### PR TITLE
[Feat/auto login] 자동 로그인 및 토큰 재발급 처리 구현

### DIFF
--- a/lib/core/constants/apis.dart
+++ b/lib/core/constants/apis.dart
@@ -8,7 +8,7 @@ abstract class Apis {
 
   /// 토큰 관련 api
   static const String postSignup = "api/auth/signup";
-  static const String reissueToken = "auth/reissue";
+  static const String reissueToken = "api/auth/reissue";
 
   /// 멤버 관련 api
   static const String fcmToken = "api/members/fcm-token";

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,5 +1,7 @@
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import 'package:ongi_app/core/di/service_locator.dart';
+import 'package:ongi_app/data/repositories/secure_storage_repository.dart';
 import 'package:ongi_app/features/auth/login/login_screen.dart';
 import 'package:ongi_app/features/auth/role_select/role_select_screen.dart';
 import 'package:ongi_app/features/auth/signup/account_info_screen.dart';
@@ -18,6 +20,36 @@ import 'routes.dart';
 
 final appRouter = GoRouter(
   initialLocation: AppRoutes.login,
+  redirect: (context, state) async {
+    final storage = getIt<SecureStorageRepository>();
+    final accessToken = await storage.readAccessToken();
+    final refreshToken = await storage.readRefreshToken();
+    final role = await storage.readRole();
+    final location = state.uri.path;
+    final homeRoute = _homeRouteForRole(role);
+
+    final isLoggedIn = accessToken != null &&
+        accessToken.isNotEmpty &&
+        refreshToken != null &&
+        refreshToken.isNotEmpty &&
+        role != null &&
+        role.isNotEmpty &&
+        homeRoute != null;
+
+    final isAuthRoute = _authRoutes.contains(location);
+    final isSignupRoute = _signupRoutes.contains(location);
+
+    if (!isLoggedIn) {
+      if (isAuthRoute || isSignupRoute) return null;
+      return AppRoutes.login;
+    }
+
+    if (isAuthRoute || isSignupRoute) {
+      return homeRoute;
+    }
+
+    return null;
+  },
   routes: [
     GoRoute(
       path: AppRoutes.login,
@@ -101,3 +133,26 @@ final appRouter = GoRouter(
     ),
   ],
 );
+
+const Set<String> _authRoutes = {
+  AppRoutes.login,
+  AppRoutes.roleSelect,
+};
+
+const Set<String> _signupRoutes = {
+  AppRoutes.signup,
+  AppRoutes.signupAccountInfo,
+  AppRoutes.signupElderlyInfo,
+  AppRoutes.signupComplete,
+};
+
+String? _homeRouteForRole(String? role) {
+  switch (role) {
+    case 'GUARDIAN':
+      return AppRoutes.guardianHome;
+    case 'ELDER':
+      return AppRoutes.elderHome;
+    default:
+      return null;
+  }
+}

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,6 +1,7 @@
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:ongi_app/core/di/service_locator.dart';
+import 'package:ongi_app/core/router/auth_redirect_notifier.dart';
 import 'package:ongi_app/data/repositories/secure_storage_repository.dart';
 import 'package:ongi_app/features/auth/login/login_screen.dart';
 import 'package:ongi_app/features/auth/role_select/role_select_screen.dart';
@@ -20,6 +21,7 @@ import 'routes.dart';
 
 final appRouter = GoRouter(
   initialLocation: AppRoutes.login,
+  refreshListenable: AuthRedirectNotifier.signal,
   redirect: (context, state) async {
     final storage = getIt<SecureStorageRepository>();
     final accessToken = await storage.readAccessToken();

--- a/lib/core/router/auth_redirect_notifier.dart
+++ b/lib/core/router/auth_redirect_notifier.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/foundation.dart';
+
+class AuthRedirectNotifier {
+  AuthRedirectNotifier._();
+
+  static final ValueNotifier<int> signal = ValueNotifier<int>(0);
+
+  static void notifyAuthChanged() {
+    signal.value++;
+  }
+}

--- a/lib/data/network/api_client.dart
+++ b/lib/data/network/api_client.dart
@@ -3,6 +3,7 @@ import 'dart:developer';
 import 'package:dio/dio.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get_it/get_it.dart';
+import 'package:ongi_app/core/router/auth_redirect_notifier.dart';
 import 'package:ongi_app/data/repositories/secure_storage_repository.dart';
 import 'package:ongi_app/data/services/auth_service.dart';
 
@@ -47,14 +48,12 @@ class ApiClient {
         }
       },
       onResponse: (response, handler) {
-        log(
-            '[Interceptor] 응답 ${response.statusCode} — ${response.requestOptions.path}');
+        log('[Interceptor] 응답 ${response.statusCode} — ${response.requestOptions.path}');
         return handler.next(response);
       },
       onError: (DioException e, handler) async {
         final requestOptions = e.requestOptions;
-        log(
-            '[Interceptor] 에러 — path=${requestOptions.path}, status=${e.response?.statusCode}');
+        log('[Interceptor] 에러 — path=${requestOptions.path}, status=${e.response?.statusCode}');
 
         if (requestOptions.extra['skipAuthToken'] == true) {
           log('[Interceptor] skipAuthToken=true, 재발급 시도 안 함');
@@ -69,8 +68,7 @@ class ApiClient {
 
         if (e.response?.statusCode == 401) {
           try {
-            log(
-                '[Interceptor] 401 → 토큰 재발급 시도 (path=${requestOptions.path})');
+            log('[Interceptor] 401 → 토큰 재발급 시도 (path=${requestOptions.path})');
 
             final authService = GetIt.instance<AuthService>();
             await authService.reissueToken();
@@ -101,6 +99,7 @@ class ApiClient {
             return handler.resolve(clonedRequest);
           } catch (refreshError) {
             log('[Interceptor] 토큰 재발급 실패: $refreshError');
+            AuthRedirectNotifier.notifyAuthChanged();
             return handler.reject(e);
           }
         }

--- a/lib/data/services/auth_service.dart
+++ b/lib/data/services/auth_service.dart
@@ -71,21 +71,45 @@ class AuthService {
 
   Future<void> reissueToken() async {
     final refreshToken = await _secureStorage.readRefreshToken();
-    if (refreshToken == null) throw Exception('리프레시 토큰이 없습니다.');
+    final loginMode = await _secureStorage.readRole();
+    if (refreshToken == null || refreshToken.isEmpty) {
+      await _secureStorage.deleteAuthData();
+      throw Exception('리프레시 토큰이 없습니다.');
+    }
+    if (loginMode == null || loginMode.isEmpty) {
+      await _secureStorage.deleteAuthData();
+      throw Exception('로그인 모드가 없습니다.');
+    }
 
-    final response = await _dio.post(
-      'reissue', // TODO: 실제 엔드포인트로 변경
-      data: {'refreshToken': refreshToken},
-      options: Options(extra: {'skipAuthToken': true}),
-    );
+    try {
+      final response = await _dio.post(
+        Apis.reissueToken,
+        data: {
+          'refreshToken': refreshToken,
+          'loginMode': loginMode,
+        },
+        options: Options(extra: {'skipAuthToken': true}),
+      );
 
-    final newAccessToken = response.data['accessToken'] as String?;
-    final newRefreshToken = response.data['refreshToken'] as String?;
+      final data = response.data['data'] as Map<String, dynamic>;
+      final newAccessToken = data['accessToken'] as String?;
+      final newRefreshToken = data['refreshToken'] as String?;
 
-    if (newAccessToken == null) throw Exception('새 액세스 토큰이 없습니다.');
-    await _secureStorage.saveAccessToken(newAccessToken);
-    if (newRefreshToken != null) {
+      if (newAccessToken == null || newRefreshToken == null) {
+        throw Exception('재발급된 토큰이 없습니다.');
+      }
+
+      await _secureStorage.saveAccessToken(newAccessToken);
       await _secureStorage.saveRefreshToken(newRefreshToken);
+    } on DioException catch (e) {
+      await _secureStorage.deleteAuthData();
+      throw ApiException(
+        e.response?.data?['message'] ?? '토큰 재발급에 실패했습니다.',
+        e.response?.statusCode,
+      );
+    } catch (e) {
+      await _secureStorage.deleteAuthData();
+      rethrow;
     }
   }
 


### PR DESCRIPTION
## Issue

- Resolves #17 

## Description
<!-- 어떤 기능을 구현했나요?    
기존 기능에서 어떤 점이 달라졌나요?  
자세한 로직이 필요하다면 함께 적어주세요!  
코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!   -->

 ### 자동 로그인 라우팅 추가
  - 앱 시작 시 Secure Storage에 저장된 인증 정보를 확인해 자동 로그인되도록 구현했습니다.
  - 확인 대상:
    - `access_token`
    - `refresh_token`
    - `role`
  - 저장된 토큰과 역할이 유효하면 로그인 화면을 건너뛰고 역할별 홈으로 이동합니다.
    - `GUARDIAN` → `/guardian/home`
    - `ELDER` → `/elder/home`
  - 로그인된 상태에서 `/login`, `/role-select`, 회원가입 플로우에 접근하면 역할별 홈으로 redirect됩니다.
  - 로그인되지 않은 상태에서 보호자/어르신 화면에 접근하면 `/login`으로 redirect됩니다.
  - 잘못된 role 값은 자동 로그인으로 인정하지 않아 redirect loop를 방지했습니다.

  ### 인증 상태 변경 notifier 추가
  - `AuthRedirectNotifier`를 추가했습니다.
  - `GoRouter.refreshListenable`에 연결해 인증 상태 변경 시 redirect가 다시 평가되도록 했습니다.
  - 토큰 재발급 실패처럼 화면 context 없이 인증 상태가 바뀌는 상황에서도 로그인 화면으로 이동할 수 있게 했습니다.

  ### 토큰 재발급 API 연동
  - 기존 TODO 상태였던 토큰 재발급 API를 실제 스펙에 맞게 구현했습니다.
  - 응답의 data.accessToken, data.refreshToken을 파싱해 Secure Storage에 저장합니다.
  - RTR 전략에 맞춰 재발급 성공 시 새 refreshToken도 함께 저장합니다.

  ### 재발급 실패 처리

  - refreshToken 또는 loginMode가 없으면 인증 데이터를 삭제하고 실패 처리합니다.
  - /api/auth/reissue가 401 등으로 실패하면 인증 데이터를 삭제합니다.
  - 네트워크 인터셉터에서 토큰 재발급 실패를 감지하면 AuthRedirectNotifier.notifyAuthChanged()를 호출합니다.
  - 라우터가 인증 데이터 삭제 상태를 다시 평가해 /login으로 이동시킵니다.

  ### API 인터셉터 연동

  - 기존 401 처리 흐름은 유지했습니다.
      - AccessToken 만료로 401 발생
      - AuthService.reissueToken() 호출
      - 성공 시 새 AccessToken으로 원 요청 재시도
      - 실패 시 로그인 화면으로 redirect
  - 재발급 요청 자체는 skipAuthToken: true로 처리해 AccessToken을 붙이지 않습니다.
  - 재시도 요청은 기존처럼 retry 플래그를 사용해 무한 재시도를 방지합니다.

  ## 변경 파일

  - lib/core/constants/apis.dart
      - reissueToken 경로를 api/auth/reissue로 수정
  - lib/core/router/app_router.dart
      - 자동 로그인 redirect 로직 추가
      - refreshListenable 연결
  - lib/core/router/auth_redirect_notifier.dart
      - 인증 상태 변경 notifier 추가
  - lib/data/services/auth_service.dart
      - 토큰 재발급 요청/응답 처리 구현
      - 재발급 실패 시 인증 데이터 삭제
  - lib/data/network/api_client.dart
      - 토큰 재발급 실패 시 라우터 refresh 신호 발생

  ## 테스트

  - dart format 실행 완료
  - flutter analyze 실행 완료
  - 신규 에러 없음
  - 기존 info만 남아 있음
      - user_role.dart enum 네이밍: GUARDIAN, ELDER

  ## 참고

  - 로그아웃 시 fcm_token은 유지하는 기존 정책과 동일하게, 재발급 실패 시에도 deleteAuthData()를 사용하므로 FCM 토큰은 삭제되지 않습니다.




## Screenshot
<!--기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요  -->

## 💬 리뷰 요구사항(선택)
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
 고민사항도 적어주세요.  -->
