### PR TITLE
[feat/device] 디바이스 연결 구현

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.VIBRATE"/>
     <application

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -63,6 +63,9 @@ PODS:
   - GoogleUtilities/UserDefaults (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
+  - mobile_scanner (7.0.0):
+    - Flutter
+    - FlutterMacOS
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
@@ -78,6 +81,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
+  - mobile_scanner (from `.symlinks/plugins/mobile_scanner/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
 
 SPEC REPOS:
@@ -103,6 +107,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_local_notifications/ios"
   flutter_secure_storage:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
+  mobile_scanner:
+    :path: ".symlinks/plugins/mobile_scanner/darwin"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
 
@@ -119,6 +125,7 @@ SPEC CHECKSUMS:
   flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
+  mobile_scanner: 77265f3dc8d580810e91849d4a0811a90467ed5e
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -28,6 +28,8 @@
 	<true/>
 	<key>NSUserNotificationUsageDescription</key>
 	<string>온기 서비스의 중요한 알림을 받기 위해 알림 권한이 필요합니다.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>디바이스 QR 코드를 스캔하기 위해 카메라 권한이 필요합니다.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -16,6 +16,7 @@ import 'package:ongi_app/features/elder/setting/elder_setting_screen.dart';
 import 'package:ongi_app/features/guardian/guardian_shell.dart';
 import 'package:ongi_app/features/guardian/home/guardian_home_screen.dart';
 import 'package:ongi_app/features/guardian/schedule/schedule_screen.dart';
+import 'package:ongi_app/features/guardian/setting/device/device_connect_screen.dart';
 import 'package:ongi_app/features/guardian/setting/guardian_setting_screen.dart';
 import 'routes.dart';
 
@@ -60,6 +61,20 @@ final appRouter = GoRouter(
     GoRoute(
       path: AppRoutes.roleSelect,
       builder: (context, state) => const RoleSelectScreen(),
+    ),
+    GoRoute(
+      path: AppRoutes.guardianDeviceQrScan,
+      builder: (context, state) => const DeviceQrScanScreen(),
+    ),
+    GoRoute(
+      path: AppRoutes.guardianDeviceWifi,
+      builder: (context, state) => DeviceWifiInputScreen(
+        deviceCode: state.uri.queryParameters['deviceCode'],
+      ),
+    ),
+    GoRoute(
+      path: AppRoutes.guardianDeviceSuccess,
+      builder: (context, state) => const DeviceConnectSuccessScreen(),
     ),
 
     // 회원가입 플로우 - SignupViewModel을 두 화면이 공유

--- a/lib/core/router/routes.dart
+++ b/lib/core/router/routes.dart
@@ -12,6 +12,9 @@ abstract class AppRoutes {
   static const guardianHome = '/guardian/home';
   static const guardianSchedule = '/guardian/schedule';
   static const guardianSettings = '/guardian/settings';
+  static const guardianDeviceQrScan = '/guardian/device/qr-scan';
+  static const guardianDeviceWifi = '/guardian/device/wifi';
+  static const guardianDeviceSuccess = '/guardian/device/success';
 
   // 어르신
   static const elderHome = '/elder/home';

--- a/lib/features/guardian/setting/device/device_connect_screen.dart
+++ b/lib/features/guardian/setting/device/device_connect_screen.dart
@@ -1,0 +1,364 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:ongi_app/core/constants/constants.dart';
+import 'package:ongi_app/core/router/routes.dart';
+import 'package:ongi_app/features/guardian/setting/device/device_connect_view_model.dart';
+import 'package:ongi_app/shared/widgets/basic_app_bar.dart';
+import 'package:ongi_app/shared/widgets/basic_button.dart';
+import 'package:ongi_app/shared/widgets/basic_text_field.dart';
+import 'package:provider/provider.dart';
+
+class DeviceQrScanScreen extends StatefulWidget {
+  const DeviceQrScanScreen({super.key});
+
+  @override
+  State<DeviceQrScanScreen> createState() => _DeviceQrScanScreenState();
+}
+
+class _DeviceQrScanScreenState extends State<DeviceQrScanScreen> {
+  final MobileScannerController _scannerController = MobileScannerController(
+    detectionSpeed: DetectionSpeed.noDuplicates,
+    formats: const [BarcodeFormat.qrCode],
+  );
+
+  bool _isNavigating = false;
+
+  @override
+  void dispose() {
+    _scannerController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _safeStopScanner() async {
+    try {
+      await _scannerController.stop();
+    } on MissingPluginException catch (error) {
+      debugPrint('MobileScanner plugin is not registered: $error');
+    }
+  }
+
+  Future<void> _safeStartScanner() async {
+    try {
+      await _scannerController.start();
+    } on MissingPluginException catch (error) {
+      debugPrint('MobileScanner plugin is not registered: $error');
+    }
+  }
+
+  Future<void> _onDetect(BarcodeCapture capture) async {
+    if (_isNavigating) return;
+
+    String? deviceCode;
+    for (final barcode in capture.barcodes) {
+      final value = barcode.rawValue;
+      if (value != null && value.trim().isNotEmpty) {
+        deviceCode = value.trim();
+        break;
+      }
+    }
+
+    if (deviceCode == null) return;
+
+    _isNavigating = true;
+    await _safeStopScanner();
+
+    if (!mounted) return;
+    await context.push(
+      '${AppRoutes.guardianDeviceWifi}?deviceCode=${Uri.encodeComponent(deviceCode)}',
+    );
+
+    if (!mounted) return;
+    _isNavigating = false;
+    await _safeStartScanner();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: OngiColor.white50,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              BasicAppBar(
+                title: '디바이스 연결',
+                subtitle: '디바이스의 QR 코드를 스캔해주세요',
+                onBackButtonPressed: () => context.pop(),
+              ),
+              const SizedBox(height: 32),
+              Expanded(
+                child: Center(
+                  child: AspectRatio(
+                    aspectRatio: 1,
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(24),
+                      child: Stack(
+                        children: [
+                          Positioned.fill(
+                            child: MobileScanner(
+                              controller: _scannerController,
+                              onDetect: _onDetect,
+                              errorBuilder: (_, error) {
+                                return _ScannerMessage(
+                                  icon: Icons.videocam_off_rounded,
+                                  message: error.errorDetails?.message ??
+                                      error.errorCode.message,
+                                );
+                              },
+                              placeholderBuilder: (_) {
+                                return const _ScannerMessage(
+                                  icon: Icons.qr_code_scanner_rounded,
+                                  message: '카메라를 준비하고 있습니다.',
+                                );
+                              },
+                            ),
+                          ),
+                          Positioned.fill(
+                            child: Container(
+                              color: Colors.black.withValues(alpha: 0.08),
+                            ),
+                          ),
+                          Center(
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Container(
+                                  width: 180,
+                                  height: 180,
+                                  decoration: BoxDecoration(
+                                    border: Border.all(
+                                      color: OngiColor.white50.withValues(
+                                        alpha: 0.5,
+                                      ),
+                                      width: 1,
+                                    ),
+                                    borderRadius: BorderRadius.circular(18),
+                                  ),
+                                ),
+                                const SizedBox(height: 20),
+                                Text(
+                                  'QR 코드를 화면 중앙에 맞춰주세요',
+                                  textAlign: TextAlign.center,
+                                  style: OngiTextStyle.body15.copyWith(
+                                    color: OngiColor.white50,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class DeviceWifiInputScreen extends StatelessWidget {
+  const DeviceWifiInputScreen({
+    super.key,
+    this.deviceCode,
+  });
+
+  final String? deviceCode;
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => DeviceConnectViewModel(),
+      child: _DeviceWifiInputView(deviceCode: deviceCode),
+    );
+  }
+}
+
+class _DeviceWifiInputView extends StatelessWidget {
+  const _DeviceWifiInputView({
+    required this.deviceCode,
+  });
+
+  final String? deviceCode;
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = context.watch<DeviceConnectViewModel>();
+
+    return Scaffold(
+      backgroundColor: OngiColor.white50,
+      body: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => FocusScope.of(context).unfocus(),
+        onVerticalDragEnd: (details) {
+          if ((details.primaryVelocity ?? 0) > 0) {
+            FocusScope.of(context).unfocus();
+          }
+        },
+        child: SafeArea(
+          child: Column(
+            children: [
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      BasicAppBar(
+                        title: 'Wi-Fi 정보 입력',
+                        subtitle: '디바이스가 사용할 Wi-Fi 정보를 입력해주세요',
+                        onBackButtonPressed: () => context.pop(),
+                      ),
+                      const SizedBox(height: 24),
+                      if (deviceCode != null) ...[
+                        Text(
+                          '인식된 디바이스',
+                          style: OngiTextStyle.body15.copyWith(
+                            color: OngiColor.systemGray03,
+                          ),
+                        ),
+                        const SizedBox(height: 6),
+                        const Text(
+                          "Ongi-device",
+                          style: OngiTextStyle.button18,
+                        ),
+                        const SizedBox(height: 24),
+                      ],
+                      BasicTextField(
+                        label: 'Wi-Fi 이름',
+                        hintText: 'Wi-Fi 이름을 입력해주세요.',
+                        controller: viewModel.ssidController,
+                        keyboardType: TextInputType.text,
+                        onChanged: (_) => viewModel.onInputChanged(),
+                      ),
+                      const SizedBox(height: 16),
+                      BasicTextField(
+                        label: 'Wi-Fi 비밀번호',
+                        hintText: 'Wi-Fi 비밀번호를 입력해주세요.',
+                        controller: viewModel.passwordController,
+                        obscureText: true,
+                        onChanged: (_) => viewModel.onInputChanged(),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
+                child: BasicButton(
+                  text: viewModel.isConnecting ? '연결 중' : '연결하기',
+                  isClickable: viewModel.canConnect,
+                  onPressed: viewModel.canConnect
+                      ? () async {
+                          await viewModel.connectDevice();
+                          if (!context.mounted) return;
+                          context.go(AppRoutes.guardianDeviceSuccess);
+                        }
+                      : null,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class DeviceConnectSuccessScreen extends StatelessWidget {
+  const DeviceConnectSuccessScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: OngiColor.white50,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Column(
+            children: [
+              const Spacer(),
+              Container(
+                width: 88,
+                height: 88,
+                decoration: const BoxDecoration(
+                  color: OngiColor.primary,
+                  shape: BoxShape.circle,
+                ),
+                child: const Icon(
+                  Icons.check_rounded,
+                  color: OngiColor.white50,
+                  size: 56,
+                ),
+              ),
+              const SizedBox(height: 24),
+              const Text('디바이스 연결 성공', style: OngiTextStyle.subTitle),
+              const SizedBox(height: 8),
+              Text(
+                '디바이스 연결이 완료되었습니다.',
+                style: OngiTextStyle.body15.copyWith(
+                  color: OngiColor.systemGray03,
+                ),
+              ),
+              const Spacer(),
+              BasicButton(
+                text: '설정으로 돌아가기',
+                isClickable: true,
+                onPressed: () => context.go(AppRoutes.guardianSettings),
+              ),
+              const SizedBox(height: 24),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ScannerMessage extends StatelessWidget {
+  const _ScannerMessage({
+    required this.icon,
+    required this.message,
+  });
+
+  final IconData icon;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: Colors.black,
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              icon,
+              color: OngiColor.white50,
+              size: 48,
+            ),
+            const SizedBox(height: 12),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Text(
+                message,
+                textAlign: TextAlign.center,
+                style: OngiTextStyle.body15.copyWith(
+                  color: OngiColor.white50,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/guardian/setting/device/device_connect_view_model.dart
+++ b/lib/features/guardian/setting/device/device_connect_view_model.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+class DeviceConnectViewModel extends ChangeNotifier {
+  final TextEditingController ssidController = TextEditingController();
+  final TextEditingController passwordController = TextEditingController();
+
+  bool _isConnecting = false;
+
+  bool get isConnecting => _isConnecting;
+
+  bool get canConnect =>
+      ssidController.text.trim().isNotEmpty &&
+      passwordController.text.trim().isNotEmpty &&
+      !_isConnecting;
+
+  void onInputChanged() {
+    notifyListeners();
+  }
+
+  Future<void> connectDevice() async {
+    if (!canConnect) return;
+
+    _isConnecting = true;
+    notifyListeners();
+
+    await Future<void>.delayed(const Duration(milliseconds: 700));
+
+    _isConnecting = false;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    ssidController.dispose();
+    passwordController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/features/guardian/setting/guardian_setting_view_model.dart
+++ b/lib/features/guardian/setting/guardian_setting_view_model.dart
@@ -32,7 +32,7 @@ class GuardianSettingViewModel extends ChangeNotifier {
       ),
       SettingMenuItem(
         title: '디바이스 연결',
-        onTap: () => debugPrint('디바이스 연결 이동'),
+        onTap: () => context.push(AppRoutes.guardianDeviceQrScan),
       ),
       SettingMenuItem(
         title: '로그아웃',

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,10 +9,12 @@ import firebase_core
 import firebase_messaging
 import flutter_local_notifications
 import flutter_secure_storage_macos
+import mobile_scanner
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
+  MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   go_router: ^14.0.0
   permission_handler: ^11.3.0
   provider: ^6.1.2
+  mobile_scanner: ^7.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Issue

- Resolves #21 

## Description
<!-- 어떤 기능을 구현했나요?    
기존 기능에서 어떤 점이 달라졌나요?  
자세한 로직이 필요하다면 함께 적어주세요!  
코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!   -->

  - 보호자 설정의 디바이스 연결 메뉴를 QR 스캔 플로우로 연결했습니다.
  - 디바이스 연결 라우트를 추가했습니다.
      - /guardian/device/qr-scan
      - /guardian/device/wifi
      - /guardian/device/success

  - QR 코드 스캔 화면을 추가했습니다.
      - mobile_scanner로 QR만 감지
      - QR 감지 후 deviceCode를 Wi-Fi 입력 화면으로 전달
      - 카메라 준비/오류 상태 메시지 처리
      - “QR 코드를 화면 중앙에 맞춰주세요” 문구를 카메라 스캔 영역 중앙 기준으로 배치

  - Wi-Fi 정보 입력 화면을 추가했습니다.
      - SSID/비밀번호 입력
      - 두 값이 모두 입력되어야 연결 버튼 활성화
      - 작은 화면/키보드 표시 시 하단 버튼 오버플로우가 나지 않도록 입력 영역을 스크롤 구조로 변경

  - 디바이스 연결 성공 화면을 추가했습니다.
  - Android/iOS 카메라 권한 설정을 추가했습니다.
  - mobile_scanner: ^7.2.0 의존성을 추가했습니다.

###  주요 파일

  - lib/features/guardian/setting/device/device_connect_screen.dart:13
  - lib/features/guardian/setting/device/device_connect_view_model.dart:3
  - lib/core/router/app_router.dart:62
  - lib/core/router/routes.dart:15
  - lib/features/guardian/setting/guardian_setting_view_model.dart:35
  - android/app/src/main/AndroidManifest.xml:2
  - ios/Runner/Info.plist:31
  - pubspec.yaml:27


## Screenshot
<!--기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요  -->

## 💬 리뷰 요구사항(선택)
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
 고민사항도 적어주세요.  -->
