### PR TITLE
[Feat/schedule] 일정 탭 api 연결

### DIFF
--- a/lib/core/constants/apis.dart
+++ b/lib/core/constants/apis.dart
@@ -19,6 +19,7 @@ abstract class Apis {
 
   /// 디바이스 관련 api
   static const String openAllDeviceSlots = "api/device/open-all";
+  static const String closeAllDeviceSlots = "api/device/close-all";
 
   /// 로그인 관련 api
   static const String postLogin = "api/auth/login";

--- a/lib/core/constants/apis.dart
+++ b/lib/core/constants/apis.dart
@@ -17,6 +17,9 @@ abstract class Apis {
   static const String getMedications = "api/medicine/medications";
   static const String getMedicineSchedules = "api/medicine/schedules";
 
+  /// 디바이스 관련 api
+  static const String openAllDeviceSlots = "api/device/open-all";
+
   /// 로그인 관련 api
   static const String postLogin = "api/auth/login";
   static const String postLoginMode = "api/auth/login/mode";

--- a/lib/core/di/service_locator.dart
+++ b/lib/core/di/service_locator.dart
@@ -3,6 +3,7 @@ import 'package:ongi_app/data/network/api_client.dart';
 import 'package:ongi_app/data/repositories/secure_storage_repository.dart';
 import 'package:ongi_app/data/services/auth_service.dart';
 import 'package:ongi_app/data/services/auth_session.dart';
+import 'package:ongi_app/data/services/device_service.dart';
 import 'package:ongi_app/data/services/member_service.dart';
 import 'package:ongi_app/data/services/medicine_service.dart';
 
@@ -30,5 +31,8 @@ void setupServiceLocator() {
   );
   getIt.registerLazySingleton<MedicineService>(
     () => MedicineService(getIt<ApiClient>().dio),
+  );
+  getIt.registerLazySingleton<DeviceService>(
+    () => DeviceService(getIt<ApiClient>().dio),
   );
 }

--- a/lib/data/services/device_service.dart
+++ b/lib/data/services/device_service.dart
@@ -17,4 +17,15 @@ class DeviceService {
       );
     }
   }
+
+  Future<void> closeAllSlots() async {
+    try {
+      await _dio.post(Apis.closeAllDeviceSlots);
+    } on DioException catch (e) {
+      throw ApiException(
+        e.response?.data?['message'] ?? '약통 닫기 명령을 전달하지 못했습니다.',
+        e.response?.statusCode,
+      );
+    }
+  }
 }

--- a/lib/data/services/device_service.dart
+++ b/lib/data/services/device_service.dart
@@ -1,0 +1,20 @@
+import 'package:dio/dio.dart';
+import 'package:ongi_app/core/constants/apis.dart';
+import 'package:ongi_app/data/network/api_exception.dart';
+
+class DeviceService {
+  final Dio _dio;
+
+  DeviceService(this._dio);
+
+  Future<void> openAllSlots() async {
+    try {
+      await _dio.post(Apis.openAllDeviceSlots);
+    } on DioException catch (e) {
+      throw ApiException(
+        e.response?.data?['message'] ?? '약통 열기 명령을 전달하지 못했습니다.',
+        e.response?.statusCode,
+      );
+    }
+  }
+}

--- a/lib/data/services/medicine_service.dart
+++ b/lib/data/services/medicine_service.dart
@@ -49,4 +49,15 @@ class MedicineService {
       );
     }
   }
+
+  Future<void> deleteMedicineSchedule({required int medicineId}) async {
+    try {
+      await _dio.delete('${Apis.getMedicineSchedules}/$medicineId');
+    } on DioException catch (e) {
+      throw ApiException(
+        e.response?.data?['message'] ?? '복약 일정을 삭제하지 못했습니다.',
+        e.response?.statusCode,
+      );
+    }
+  }
 }

--- a/lib/data/services/medicine_service.dart
+++ b/lib/data/services/medicine_service.dart
@@ -50,6 +50,24 @@ class MedicineService {
     }
   }
 
+  Future<void> saveMedicineSchedules({
+    required List<Map<String, String>> schedules,
+  }) async {
+    try {
+      await _dio.post(
+        Apis.getMedicineSchedules,
+        data: {
+          'schedules': schedules,
+        },
+      );
+    } on DioException catch (e) {
+      throw ApiException(
+        e.response?.data?['message'] ?? '복약 일정을 저장하지 못했습니다.',
+        e.response?.statusCode,
+      );
+    }
+  }
+
   Future<void> deleteMedicineSchedule({required int medicineId}) async {
     try {
       await _dio.delete('${Apis.getMedicineSchedules}/$medicineId');

--- a/lib/features/guardian/guardian_shell.dart
+++ b/lib/features/guardian/guardian_shell.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ongi_app/features/guardian/nav/guardian_navigation.dart';
+import 'package:ongi_app/features/guardian/nav/guardian_tab_refresh_notifier.dart';
 
 class GuardianShell extends StatelessWidget {
   const GuardianShell({super.key, required this.navigationShell});
@@ -13,10 +14,13 @@ class GuardianShell extends StatelessWidget {
       body: navigationShell,
       bottomNavigationBar: GuardianNavigation(
         currentIndex: navigationShell.currentIndex,
-        onTap: (index) => navigationShell.goBranch(
-          index,
-          initialLocation: index == navigationShell.currentIndex,
-        ),
+        onTap: (index) {
+          navigationShell.goBranch(
+            index,
+            initialLocation: index == navigationShell.currentIndex,
+          );
+          GuardianTabRefreshNotifier.refresh(index);
+        },
       ),
     );
   }

--- a/lib/features/guardian/home/guardian_home_screen.dart
+++ b/lib/features/guardian/home/guardian_home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:ongi_app/core/constants/constants.dart';
+import 'package:ongi_app/features/guardian/nav/guardian_tab_refresh_notifier.dart';
 import 'package:ongi_app/shared/widgets/custom_header.dart';
 import 'package:provider/provider.dart';
 
@@ -17,8 +18,29 @@ class GuardianHomeScreen extends StatelessWidget {
   }
 }
 
-class _GuardianHomeView extends StatelessWidget {
+class _GuardianHomeView extends StatefulWidget {
   const _GuardianHomeView();
+
+  @override
+  State<_GuardianHomeView> createState() => _GuardianHomeViewState();
+}
+
+class _GuardianHomeViewState extends State<_GuardianHomeView> {
+  @override
+  void initState() {
+    super.initState();
+    GuardianTabRefreshNotifier.homeSignal.addListener(_refreshHome);
+  }
+
+  @override
+  void dispose() {
+    GuardianTabRefreshNotifier.homeSignal.removeListener(_refreshHome);
+    super.dispose();
+  }
+
+  void _refreshHome() {
+    context.read<GuardianHomeViewModel>().loadMedications();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/guardian/nav/guardian_tab_refresh_notifier.dart
+++ b/lib/features/guardian/nav/guardian_tab_refresh_notifier.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/foundation.dart';
+
+class GuardianTabRefreshNotifier {
+  GuardianTabRefreshNotifier._();
+
+  static final ValueNotifier<int> homeSignal = ValueNotifier<int>(0);
+  static final ValueNotifier<int> scheduleSignal = ValueNotifier<int>(0);
+  static final ValueNotifier<int> settingSignal = ValueNotifier<int>(0);
+
+  static void refresh(int index) {
+    switch (index) {
+      case 0:
+        homeSignal.value++;
+        break;
+      case 1:
+        scheduleSignal.value++;
+        break;
+      case 2:
+        settingSignal.value++;
+        break;
+    }
+  }
+}

--- a/lib/features/guardian/schedule/schedule_screen.dart
+++ b/lib/features/guardian/schedule/schedule_screen.dart
@@ -149,10 +149,59 @@ class _GuardianScheduleScreenState extends State<GuardianScheduleScreen> {
         return _buildMedicationCard(
           index: index + 1,
           medication: medication,
-          onDelete: () => _viewModel.removeMedication(medication.id),
+          onDelete: () => _showDeleteMedicationDialog(medication),
         );
       },
     );
+  }
+
+  Future<void> _showDeleteMedicationDialog(MedicationModel medication) async {
+    final shouldDelete = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('약 삭제', style: OngiTextStyle.button18),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                medication.name,
+                style: OngiTextStyle.button18,
+              ),
+              const SizedBox(height: 6),
+              Text(
+                '복용 시간 ${medication.time}',
+                style: OngiTextStyle.body15.copyWith(
+                  color: Colors.grey,
+                ),
+              ),
+              const SizedBox(height: 16),
+              const Text(
+                '진짜로 삭제하겠습니까?',
+                style: OngiTextStyle.body15,
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('취소'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: const Text(
+                '삭제',
+                style: TextStyle(color: Colors.red),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (shouldDelete != true) return;
+    _viewModel.removeMedication(medication.id);
   }
 
   Future<void> _showAddMedicationDialog() async {

--- a/lib/features/guardian/schedule/schedule_screen.dart
+++ b/lib/features/guardian/schedule/schedule_screen.dart
@@ -99,7 +99,7 @@ class _GuardianScheduleScreenState extends State<GuardianScheduleScreen> {
                     child: BasicButton(
                       text: '약통 열기',
                       isClickable: true,
-                      onPressed: () => _viewModel.openPillBox(),
+                      onPressed: _openPillBox,
                     ),
                   ),
                 ],
@@ -154,6 +154,26 @@ class _GuardianScheduleScreenState extends State<GuardianScheduleScreen> {
         );
       },
     );
+  }
+
+  Future<void> _openPillBox() async {
+    try {
+      await _viewModel.openPillBox();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('약통 열기 명령을 전달했습니다.')),
+      );
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(e.message)),
+      );
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('약통 열기 명령을 전달하지 못했습니다.')),
+      );
+    }
   }
 
   Future<void> _showDeleteMedicationDialog(MedicationModel medication) async {

--- a/lib/features/guardian/schedule/schedule_screen.dart
+++ b/lib/features/guardian/schedule/schedule_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:ongi_app/core/constants/styles.dart';
+import 'package:ongi_app/features/guardian/nav/guardian_tab_refresh_notifier.dart';
 import 'package:ongi_app/features/guardian/schedule/schedule_view_model.dart';
 import 'package:ongi_app/shared/widgets/basic_button.dart';
 import 'package:ongi_app/shared/widgets/basic_text_field.dart';
@@ -20,12 +21,18 @@ class _GuardianScheduleScreenState extends State<GuardianScheduleScreen> {
   void initState() {
     super.initState();
     _viewModel.loadInitialData();
+    GuardianTabRefreshNotifier.scheduleSignal.addListener(_refreshSchedule);
   }
 
   @override
   void dispose() {
+    GuardianTabRefreshNotifier.scheduleSignal.removeListener(_refreshSchedule);
     _viewModel.dispose();
     super.dispose();
+  }
+
+  void _refreshSchedule() {
+    _viewModel.loadInitialData();
   }
 
   @override

--- a/lib/features/guardian/schedule/schedule_screen.dart
+++ b/lib/features/guardian/schedule/schedule_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:ongi_app/core/constants/styles.dart';
+import 'package:ongi_app/data/network/api_exception.dart';
 import 'package:ongi_app/features/guardian/nav/guardian_tab_refresh_notifier.dart';
 import 'package:ongi_app/features/guardian/schedule/schedule_view_model.dart';
 import 'package:ongi_app/shared/widgets/basic_button.dart';
@@ -201,7 +202,24 @@ class _GuardianScheduleScreenState extends State<GuardianScheduleScreen> {
     );
 
     if (shouldDelete != true) return;
-    _viewModel.removeMedication(medication.id);
+
+    try {
+      await _viewModel.removeMedication(medication);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('복약 일정이 삭제되었습니다.')),
+      );
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(e.message)),
+      );
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('복약 일정을 삭제하지 못했습니다.')),
+      );
+    }
   }
 
   Future<void> _showAddMedicationDialog() async {

--- a/lib/features/guardian/schedule/schedule_screen.dart
+++ b/lib/features/guardian/schedule/schedule_screen.dart
@@ -236,7 +236,24 @@ class _GuardianScheduleScreenState extends State<GuardianScheduleScreen> {
     );
 
     if (medication == null) return;
-    _viewModel.addMedication(medication.name, medication.time);
+
+    try {
+      await _viewModel.addMedication(medication.name, medication.time);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('복약 일정이 추가되었습니다.')),
+      );
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(e.message)),
+      );
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('복약 일정을 추가하지 못했습니다.')),
+      );
+    }
   }
 
   // 약 리스트의 단일 아이템 카드 빌더

--- a/lib/features/guardian/schedule/schedule_screen.dart
+++ b/lib/features/guardian/schedule/schedule_screen.dart
@@ -19,7 +19,7 @@ class _GuardianScheduleScreenState extends State<GuardianScheduleScreen> {
   @override
   void initState() {
     super.initState();
-    _viewModel.loadHeaderData();
+    _viewModel.loadInitialData();
   }
 
   @override
@@ -82,22 +82,7 @@ class _GuardianScheduleScreenState extends State<GuardianScheduleScreen> {
 
                   // 3. 약 목록 리스트 영역
                   Expanded(
-                    child: _viewModel.medications.isEmpty
-                        ? const Center(child: Text('등록된 약 일정이 없습니다.'))
-                        : ListView.separated(
-                            itemCount: _viewModel.medications.length,
-                            separatorBuilder: (context, index) =>
-                                const SizedBox(height: 12),
-                            itemBuilder: (context, index) {
-                              final medication = _viewModel.medications[index];
-                              return _buildMedicationCard(
-                                index: index + 1,
-                                medication: medication,
-                                onDelete: () =>
-                                    _viewModel.removeMedication(medication.id),
-                              );
-                            },
-                          ),
+                    child: _buildMedicationListContent(primaryColor),
                   ),
 
                   // 4. 하단 '약통 열기' 버튼
@@ -115,6 +100,51 @@ class _GuardianScheduleScreenState extends State<GuardianScheduleScreen> {
           },
         ),
       ),
+    );
+  }
+
+  Widget _buildMedicationListContent(Color primaryColor) {
+    if (_viewModel.isMedicationLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_viewModel.medicationErrorMessage != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              _viewModel.medicationErrorMessage!,
+              style: OngiTextStyle.body15,
+            ),
+            const SizedBox(height: 8),
+            TextButton(
+              onPressed: _viewModel.loadMedications,
+              child: Text(
+                '다시 불러오기',
+                style: OngiTextStyle.body15.copyWith(color: primaryColor),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (_viewModel.medications.isEmpty) {
+      return const Center(child: Text('등록된 약 일정이 없습니다.'));
+    }
+
+    return ListView.separated(
+      itemCount: _viewModel.medications.length,
+      separatorBuilder: (context, index) => const SizedBox(height: 12),
+      itemBuilder: (context, index) {
+        final medication = _viewModel.medications[index];
+        return _buildMedicationCard(
+          index: index + 1,
+          medication: medication,
+          onDelete: () => _viewModel.removeMedication(medication.id),
+        );
+      },
     );
   }
 

--- a/lib/features/guardian/schedule/schedule_screen.dart
+++ b/lib/features/guardian/schedule/schedule_screen.dart
@@ -223,6 +223,13 @@ class _GuardianScheduleScreenState extends State<GuardianScheduleScreen> {
   }
 
   Future<void> _showAddMedicationDialog() async {
+    if (_viewModel.medications.length >= 6) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('최대 6개만 등록 가능해요')),
+      );
+      return;
+    }
+
     final medication = await showDialog<_MedicationInput>(
       context: context,
       builder: (_) => const _AddMedicationDialog(),

--- a/lib/features/guardian/schedule/schedule_screen.dart
+++ b/lib/features/guardian/schedule/schedule_screen.dart
@@ -97,9 +97,9 @@ class _GuardianScheduleScreenState extends State<GuardianScheduleScreen> {
                   Padding(
                     padding: const EdgeInsets.only(bottom: 24),
                     child: BasicButton(
-                      text: '약통 열기',
+                      text: _viewModel.pillBoxButtonText,
                       isClickable: true,
-                      onPressed: _openPillBox,
+                      onPressed: _togglePillBox,
                     ),
                   ),
                 ],
@@ -156,12 +156,12 @@ class _GuardianScheduleScreenState extends State<GuardianScheduleScreen> {
     );
   }
 
-  Future<void> _openPillBox() async {
+  Future<void> _togglePillBox() async {
     try {
-      await _viewModel.openPillBox();
+      final isOpen = await _viewModel.togglePillBox();
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('약통 열기 명령을 전달했습니다.')),
+        SnackBar(content: Text(isOpen ? '약통이 열렸습니다' : '약통이 닫혔습니다')),
       );
     } on ApiException catch (e) {
       if (!mounted) return;
@@ -171,7 +171,7 @@ class _GuardianScheduleScreenState extends State<GuardianScheduleScreen> {
     } catch (_) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('약통 열기 명령을 전달하지 못했습니다.')),
+        const SnackBar(content: Text('약통 명령을 전달하지 못했습니다.')),
       );
     }
   }

--- a/lib/features/guardian/schedule/schedule_view_model.dart
+++ b/lib/features/guardian/schedule/schedule_view_model.dart
@@ -6,11 +6,13 @@ import 'package:ongi_app/data/services/medicine_service.dart';
 // 약 데이터 모델
 class MedicationModel {
   final String id;
+  final int? medicineId;
   final String name;
   final String time;
 
   MedicationModel({
     required this.id,
+    this.medicineId,
     required this.name,
     required this.time,
   });
@@ -64,6 +66,7 @@ class ScheduleViewModel extends ChangeNotifier {
             final schedule = entry.value;
             return MedicationModel(
               id: (schedule.medicineId ?? index).toString(),
+              medicineId: schedule.medicineId,
               name: schedule.medicineName,
               time: _formatScheduledTime(schedule.scheduledTime),
             );
@@ -86,8 +89,16 @@ class ScheduleViewModel extends ChangeNotifier {
   }
 
   // 약 삭제 기능 (삭제 텍스트 버튼 클릭 시)
-  void removeMedication(String id) {
-    _medications.removeWhere((med) => med.id == id);
+  Future<void> removeMedication(MedicationModel medication) async {
+    final medicineId = medication.medicineId ?? int.tryParse(medication.id);
+    if (medicineId == null) {
+      _medications.removeWhere((med) => med.id == medication.id);
+      notifyListeners();
+      return;
+    }
+
+    await _medicineService.deleteMedicineSchedule(medicineId: medicineId);
+    _medications.removeWhere((med) => med.id == medication.id);
     notifyListeners(); // UI 업데이트 알림
   }
 

--- a/lib/features/guardian/schedule/schedule_view_model.dart
+++ b/lib/features/guardian/schedule/schedule_view_model.dart
@@ -82,10 +82,22 @@ class ScheduleViewModel extends ChangeNotifier {
   }
 
   // 약 추가 기능 (추가하기 버튼 클릭 시)
-  void addMedication(String name, String time) {
-    final newId = (DateTime.now().millisecondsSinceEpoch).toString();
-    _medications.add(MedicationModel(id: newId, name: name, time: time));
-    notifyListeners(); // UI 업데이트 알림
+  Future<void> addMedication(String name, String time) async {
+    final schedules = [
+      ..._medications.map(
+        (medication) => {
+          'name': medication.name,
+          'scheduledTime': _formatRequestTime(medication.time),
+        },
+      ),
+      {
+        'name': name,
+        'scheduledTime': _formatRequestTime(time),
+      },
+    ];
+
+    await _medicineService.saveMedicineSchedules(schedules: schedules);
+    await loadMedications();
   }
 
   // 약 삭제 기능 (삭제 텍스트 버튼 클릭 시)
@@ -122,5 +134,16 @@ class ScheduleViewModel extends ChangeNotifier {
     final parts = scheduledTime.split(':');
     if (parts.length < 2) return scheduledTime;
     return '${parts[0]}:${parts[1]}';
+  }
+
+  String _formatRequestTime(String time) {
+    final parts = time.split(':');
+    if (parts.length >= 3) {
+      return '${parts[0].padLeft(2, '0')}:${parts[1].padLeft(2, '0')}:${parts[2].padLeft(2, '0')}';
+    }
+    if (parts.length == 2) {
+      return '${parts[0].padLeft(2, '0')}:${parts[1].padLeft(2, '0')}:00';
+    }
+    return time;
   }
 }

--- a/lib/features/guardian/schedule/schedule_view_model.dart
+++ b/lib/features/guardian/schedule/schedule_view_model.dart
@@ -29,6 +29,7 @@ class ScheduleViewModel extends ChangeNotifier {
 
   final List<MedicationModel> _medications = [];
   bool _isMedicationLoading = false;
+  bool _isPillBoxOpen = false;
   String? _medicationErrorMessage;
 
   String get todayText => _formatDate(_today);
@@ -37,6 +38,8 @@ class ScheduleViewModel extends ChangeNotifier {
   bool get isMedicationLoading => _isMedicationLoading;
   String? get medicationErrorMessage => _medicationErrorMessage;
   List<MedicationModel> get medications => List.unmodifiable(_medications);
+  String get pillBoxButtonText => _isPillBoxOpen ? '약통 닫기' : '약통 열기';
+  bool get isPillBoxOpen => _isPillBoxOpen;
 
   Future<void> loadInitialData() async {
     await Future.wait([
@@ -117,8 +120,18 @@ class ScheduleViewModel extends ChangeNotifier {
   }
 
   // 약통 열기 버튼 기능
-  Future<void> openPillBox() async {
-    await _deviceService.openAllSlots();
+  Future<bool> togglePillBox() async {
+    final willOpen = !_isPillBoxOpen;
+
+    if (willOpen) {
+      await _deviceService.openAllSlots();
+    } else {
+      await _deviceService.closeAllSlots();
+    }
+
+    _isPillBoxOpen = willOpen;
+    notifyListeners();
+    return _isPillBoxOpen;
   }
 
   String _formatDate(DateTime date) {

--- a/lib/features/guardian/schedule/schedule_view_model.dart
+++ b/lib/features/guardian/schedule/schedule_view_model.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:ongi_app/core/di/service_locator.dart';
 import 'package:ongi_app/data/repositories/secure_storage_repository.dart';
+import 'package:ongi_app/data/services/device_service.dart';
 import 'package:ongi_app/data/services/medicine_service.dart';
 
 // 약 데이터 모델
@@ -21,6 +22,7 @@ class MedicationModel {
 // 일정 화면 뷰모델
 class ScheduleViewModel extends ChangeNotifier {
   final _medicineService = getIt<MedicineService>();
+  final _deviceService = getIt<DeviceService>();
   final _storage = getIt<SecureStorageRepository>();
   final DateTime _today = DateTime.now();
   String _elderName = '어르신';
@@ -115,9 +117,8 @@ class ScheduleViewModel extends ChangeNotifier {
   }
 
   // 약통 열기 버튼 기능
-  void openPillBox() {
-    // TODO: 하드웨어 디바이스 연동 또는 API 호출 로직
-    debugPrint('약통 열기 명령 전송');
+  Future<void> openPillBox() async {
+    await _deviceService.openAllSlots();
   }
 
   String _formatDate(DateTime date) {

--- a/lib/features/guardian/schedule/schedule_view_model.dart
+++ b/lib/features/guardian/schedule/schedule_view_model.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:ongi_app/core/di/service_locator.dart';
 import 'package:ongi_app/data/repositories/secure_storage_repository.dart';
+import 'package:ongi_app/data/services/medicine_service.dart';
 
 // 약 데이터 모델
 class MedicationModel {
@@ -17,24 +18,62 @@ class MedicationModel {
 
 // 일정 화면 뷰모델
 class ScheduleViewModel extends ChangeNotifier {
+  final _medicineService = getIt<MedicineService>();
   final _storage = getIt<SecureStorageRepository>();
   final DateTime _today = DateTime.now();
   String _elderName = '어르신';
 
-  // 샘플 데이터 (이미지 기준: 1. 혈압약 09:00)
-  final List<MedicationModel> _medications = [
-    MedicationModel(id: '1', name: '혈압약', time: '09:00'),
-  ];
+  final List<MedicationModel> _medications = [];
+  bool _isMedicationLoading = false;
+  String? _medicationErrorMessage;
 
   String get todayText => _formatDate(_today);
   String get memberName => _elderName;
   String get greeting => '오늘도 따뜻한 하루 보내세요';
-  List<MedicationModel> get medications => _medications;
+  bool get isMedicationLoading => _isMedicationLoading;
+  String? get medicationErrorMessage => _medicationErrorMessage;
+  List<MedicationModel> get medications => List.unmodifiable(_medications);
+
+  Future<void> loadInitialData() async {
+    await Future.wait([
+      loadHeaderData(),
+      loadMedications(),
+    ]);
+  }
 
   Future<void> loadHeaderData() async {
     final elderName = await _storage.readElderName();
     if (elderName != null && elderName.isNotEmpty) {
       _elderName = elderName;
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadMedications() async {
+    _isMedicationLoading = true;
+    _medicationErrorMessage = null;
+    notifyListeners();
+
+    try {
+      final schedules = await _medicineService.getMedicineSchedules();
+      _medications
+        ..clear()
+        ..addAll(
+          schedules.asMap().entries.map((entry) {
+            final index = entry.key;
+            final schedule = entry.value;
+            return MedicationModel(
+              id: (schedule.medicineId ?? index).toString(),
+              name: schedule.medicineName,
+              time: _formatScheduledTime(schedule.scheduledTime),
+            );
+          }),
+        );
+    } catch (e) {
+      _medications.clear();
+      _medicationErrorMessage = '약 일정을 불러오지 못했습니다.';
+    } finally {
+      _isMedicationLoading = false;
       notifyListeners();
     }
   }
@@ -66,5 +105,11 @@ class ScheduleViewModel extends ChangeNotifier {
     final weekday = weekdays[date.weekday - 1];
 
     return '$year. $month. $day($weekday)';
+  }
+
+  String _formatScheduledTime(String scheduledTime) {
+    final parts = scheduledTime.split(':');
+    if (parts.length < 2) return scheduledTime;
+    return '${parts[0]}:${parts[1]}';
   }
 }

--- a/lib/features/guardian/setting/guardian_setting_screen.dart
+++ b/lib/features/guardian/setting/guardian_setting_screen.dart
@@ -1,10 +1,32 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:ongi_app/core/constants/constants.dart';
+import 'package:ongi_app/features/guardian/nav/guardian_tab_refresh_notifier.dart';
 import 'package:ongi_app/features/guardian/setting/guardian_setting_view_model.dart';
 
-class GuardianSettingScreen extends StatelessWidget {
+class GuardianSettingScreen extends StatefulWidget {
   const GuardianSettingScreen({super.key});
+
+  @override
+  State<GuardianSettingScreen> createState() => _GuardianSettingScreenState();
+}
+
+class _GuardianSettingScreenState extends State<GuardianSettingScreen> {
+  @override
+  void initState() {
+    super.initState();
+    GuardianTabRefreshNotifier.settingSignal.addListener(_refreshSetting);
+  }
+
+  @override
+  void dispose() {
+    GuardianTabRefreshNotifier.settingSignal.removeListener(_refreshSetting);
+    super.dispose();
+  }
+
+  void _refreshSetting() {
+    setState(() {});
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Issue

- Resolves #22

## Description
<!-- 어떤 기능을 구현했나요?    
기존 기능에서 어떤 점이 달라졌나요?  
자세한 로직이 필요하다면 함께 적어주세요!  
코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!   -->

 현재 브랜치 feat/schedule은 보호자 일정 탭을 실제 API 기반으로 동작하게 만든 작업입니다. 기존에는 일정 탭의 약 데이터가 로컬 샘플/임시 상태 중심이었는데, 이 브랜치에서는
  복약 스케줄 조회, 추가, 삭제, 약통 열기/닫기 명령까지 서버와 연결했습니다.

###  복약 스케줄 조회
  일정 탭 진입 시 lib/features/guardian/schedule/schedule_view_model.dart:41의 loadInitialData()가 호출됩니다. 이 메서드는 헤더에 필요한 어르신 이름과 복약 스케줄 목록을
  함께 불러옵니다.

  복약 스케줄 목록은 lib/data/services/medicine_service.dart:37의 getMedicineSchedules()를 통해 GET /api/medicine/schedules에서 가져옵니다. 응답 DTO는 기존 lib/data/dto/
  response/medicine_schedule_response_dto.dart:1를 사용합니다.

  화면에서는 lib/features/guardian/schedule/schedule_screen.dart:112의 _buildMedicationListContent()에서 상태를 나눠 보여줍니다.

  - 로딩 중: CircularProgressIndicator
  - 조회 실패: 에러 메시지와 다시 불러오기
  - 데이터 없음: 등록된 약 일정이 없습니다.
  - 데이터 있음: 약 카드 리스트

  서버 시간이 08:30:00처럼 내려와도 화면에는 08:30 형태로 표시되도록 lib/features/guardian/schedule/schedule_view_model.dart:146에서 포맷합니다.

###  복약 스케줄 추가
  약 추가는 lib/features/guardian/schedule/schedule_screen.dart:225의 _showAddMedicationDialog()에서 시작됩니다.

  추가 전 현재 등록된 약이 6개 이상이면 다이얼로그를 열지 않고 최대 6개만 등록 가능해요 스낵바를 띄운 뒤 종료합니다. 6개 미만일 때만 기존 약 추가 다이얼로그를 보여줍니다.

  사용자가 약 이름과 복용 시간을 입력하고 추가하면 lib/features/guardian/schedule/schedule_view_model.dart:85의 addMedication()이 실행됩니다. API 명세상 POST /api/
  medicine/schedules는 “기존 스케줄 전체 삭제 후 재등록” 방식이므로, 새 약 하나만 보내지 않고 기존 목록에 새 약을 더한 전체 목록을 서버에 보냅니다.

  사용자가 08:30처럼 입력하면 lib/features/guardian/schedule/schedule_view_model.dart:152에서 08:30:00으로 변환합니다. 저장 성공 후에는 loadMedications()를 다시 호출해 서
  버 기준 목록으로 갱신합니다. 성공 시 복약 일정이 추가되었습니다. 스낵바가 뜹니다.

###  복약 스케줄 삭제
  약 카드의 삭제를 누르면 바로 삭제하지 않고 lib/features/guardian/schedule/schedule_screen.dart:178의 _showDeleteMedicationDialog()가 열립니다.

  다이얼로그에는 삭제 대상 약의 이름과 복용 시간이 표시되고, 진짜로 삭제하겠습니까? 확인 문구가 나옵니다. 취소를 누르면 아무 동작도 하지 않고, 삭제를 눌러야 실제 삭제 API
  를 호출합니다.

  삭제 API는 lib/data/services/medicine_service.dart:71의 deleteMedicineSchedule()에서 호출합니다.

  - DELETE /api/medicine/schedules/{medicineId}

  삭제가 성공하면 로컬 목록에서도 해당 약을 제거하고 복약 일정이 삭제되었습니다. 스낵바를 띄웁니다. 실패하면 서버의 message를 우선 표시하고, 알 수 없는 실패는 복약 일정을
  삭제하지 못했습니다.를 표시합니다.

###  약통 열기/닫기
  디바이스 관련 API는 새 파일 lib/data/services/device_service.dart:5로 분리했습니다. lib/core/di/service_locator.dart:35에 DeviceService도 DI 등록했습니다.

  추가된 API 상수는 lib/core/constants/apis.dart:20에 있습니다.

  - POST /api/device/open-all
  - POST /api/device/close-all

  일정 화면 하단 버튼은 처음에는 약통 열기로 표시됩니다. 버튼을 누르면 lib/features/guardian/schedule/schedule_view_model.dart:123의 togglePillBox()가 실행됩니다.

  현재 상태가 닫힘이면:

  - DeviceService.openAllSlots() 호출
  - 성공 후 내부 상태 _isPillBoxOpen = true
  - 버튼 텍스트가 약통 닫기로 변경
  - 약통이 열렸습니다 스낵바 표시

  현재 상태가 열림이면:

  - DeviceService.closeAllSlots() 호출
  - 성공 후 내부 상태 _isPillBoxOpen = false
  - 버튼 텍스트가 약통 열기로 변경
  - 약통이 닫혔습니다 스낵바 표시

  실패 시에는 서버 메시지를 우선 보여주고, 알 수 없는 실패는 약통 명령을 전달하지 못했습니다.로 표시합니다.

###  바텀 네비게이션 리로드
  기존 보호자 화면은 StatefulShellRoute.indexedStack 구조라 탭 화면이 보존됩니다. 이 구조에서는 탭을 다시 눌러도 화면이 새로 생성되지 않기 때문에, 데이터를 다시 불러오려면
  별도 신호가 필요합니다.

  이를 위해 lib/features/guardian/nav/guardian_tab_refresh_notifier.dart:3를 추가했습니다. 홈, 일정, 설정 탭별로 ValueNotifier<int> 신호를 가지고 있습니다.

  lib/features/guardian/guardian_shell.dart:17에서 바텀 네비게이션 탭을 누르면 기존처럼 navigationShell.goBranch()를 실행한 뒤, GuardianTabRefreshNotifier.refresh(index)를
  호출합니다.

  각 탭의 동작은 다음과 같습니다.

  - 홈: lib/features/guardian/home/guardian_home_screen.dart:35에서 loadMedications() 재호출
  - 일정: lib/features/guardian/schedule/schedule_screen.dart:33에서 loadInitialData() 재호출
  - 설정: lib/features/guardian/setting/guardian_setting_screen.dart:27에서 setState()로 rebuild

  즉, 화면 보존 구조는 유지하면서 탭을 누를 때마다 최신 데이터를 다시 가져오도록 처리했습니다.

 ### 에러 처리
  API 호출 실패는 서비스 계층에서 ApiException으로 변환합니다. 서버 응답의 message가 있으면 그 값을 사용하고, 없으면 화면별 기본 메시지를 사용합니다.

  예를 들어:

  - 복약 일정 조회 실패: 약 일정을 불러오지 못했습니다.
  - 복약 일정 추가 실패: 복약 일정을 추가하지 못했습니다.
  - 복약 일정 삭제 실패: 복약 일정을 삭제하지 못했습니다.
  - 약통 명령 실패: 약통 명령을 전달하지 못했습니다.



## Screenshot
<!--기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요  -->

## 💬 리뷰 요구사항(선택)
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
 고민사항도 적어주세요.  -->
