### PR TITLE
[Fix] 어르신 홈 화면 복약 API 변경

### DIFF
--- a/lib/core/constants/apis.dart
+++ b/lib/core/constants/apis.dart
@@ -15,6 +15,7 @@ abstract class Apis {
 
   /// 복약 관련 api
   static const String getMedications = "api/medicine/medications";
+  static const String getDailyMedications = "api/medicine/medications/daily";
   static const String getMedicineSchedules = "api/medicine/schedules";
 
   /// 디바이스 관련 api

--- a/lib/data/dto/response/daily_medication_response_dto.dart
+++ b/lib/data/dto/response/daily_medication_response_dto.dart
@@ -1,0 +1,36 @@
+class DailyMedicationResponseDto {
+  final int medicineId;
+  final String medicineName;
+  final String scheduledTime;
+  final int? slotNumber;
+  final int? deviceId;
+  final bool taken;
+  final String? result;
+  final DateTime? recordedAt;
+
+  const DailyMedicationResponseDto({
+    required this.medicineId,
+    required this.medicineName,
+    required this.scheduledTime,
+    this.slotNumber,
+    this.deviceId,
+    required this.taken,
+    this.result,
+    this.recordedAt,
+  });
+
+  factory DailyMedicationResponseDto.fromJson(Map<String, dynamic> json) {
+    return DailyMedicationResponseDto(
+      medicineId: json['medicineId'] as int,
+      medicineName: json['medicineName'] as String,
+      scheduledTime: json['scheduledTime'] as String,
+      slotNumber: json['slotNumber'] as int?,
+      deviceId: json['deviceId'] as int?,
+      taken: json['taken'] as bool? ?? false,
+      result: json['result'] as String?,
+      recordedAt: json['recordedAt'] == null
+          ? null
+          : DateTime.tryParse(json['recordedAt'] as String),
+    );
+  }
+}

--- a/lib/data/services/medicine_service.dart
+++ b/lib/data/services/medicine_service.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:ongi_app/core/constants/apis.dart';
+import 'package:ongi_app/data/dto/response/daily_medication_response_dto.dart';
 import 'package:ongi_app/data/dto/response/medicine_schedule_response_dto.dart';
 import 'package:ongi_app/data/dto/response/medication_record_response_dto.dart';
 import 'package:ongi_app/data/network/api_exception.dart';
@@ -25,6 +26,29 @@ class MedicineService {
       return data
           .map((e) =>
               MedicationRecordResponseDto.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw ApiException(
+        e.response?.data?['message'] ?? '복약 기록을 불러오지 못했습니다.',
+        e.response?.statusCode,
+      );
+    }
+  }
+
+  Future<List<DailyMedicationResponseDto>> getDailyMedications({
+    required String date,
+  }) async {
+    try {
+      final response = await _dio.get(
+        Apis.getDailyMedications,
+        queryParameters: {
+          'date': date,
+        },
+      );
+      final data = response.data['data'] as List<dynamic>;
+      return data
+          .map((e) =>
+              DailyMedicationResponseDto.fromJson(e as Map<String, dynamic>))
           .toList();
     } on DioException catch (e) {
       throw ApiException(

--- a/lib/features/guardian/home/guardian_home_view_model.dart
+++ b/lib/features/guardian/home/guardian_home_view_model.dart
@@ -34,20 +34,12 @@ class GuardianHomeViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final elderId = await _storage.getElderId();
       final elderName = await _storage.readElderName();
       if (elderName != null && elderName.isNotEmpty) {
         _elderName = elderName;
       }
 
-      if (elderId == null) {
-        _medications.clear();
-        _medicationErrorMessage = '어르신 정보를 찾을 수 없습니다.';
-        return;
-      }
-
-      final records = await _medicineService.getMedicationRecords(
-        elderId: elderId,
+      final records = await _medicineService.getDailyMedications(
         date: queryDate,
       );
 
@@ -57,7 +49,7 @@ class GuardianHomeViewModel extends ChangeNotifier {
           (record) => MedicationItem(
             title: record.medicineName,
             time: _formatScheduledTime(record.scheduledTime),
-            isChecked: record.result == 'TAKEN',
+            isChecked: record.taken || record.result == 'TAKEN',
           ),
         ));
     } catch (e) {


### PR DESCRIPTION
## Issue

- Resolves #

## Description
<!-- 어떤 기능을 구현했나요?    
기존 기능에서 어떤 점이 달라졌나요?  
자세한 로직이 필요하다면 함께 적어주세요!  
코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!   -->

### 변경 내용
  - 어르신 홈 화면의 복약 기록 조회 API를 기존 `getMedicationRecords`에서 일일 복약 조회 API로 변경했습니다.
  - `api/medicine/medications/daily` 엔드포인트 상수를 추가했습니다.
  - 일일 복약 응답을 처리하기 위한 `DailyMedicationResponseDto`를 추가했습니다.
  - `MedicineService`에 `getDailyMedications(date)` 메서드를 추가했습니다.
  - 홈 화면 복약 완료 여부를 `taken` 값 기준으로 반영하고, 기존 `result == 'TAKEN'` 조건도 함께 유지했습니다.
  - 더 이상 홈 화면 복약 조회 시 `elderId`를 직접 넘기지 않도록 변경했습니다.

  ### 변경 이유
  - 어르신 홈 화면에서 사용하는 복약 데이터 API 스펙이 일일 복약 조회 API로 변경되어, 새로운 응답 구조에 맞게 서비
  스와 뷰모델을 수정했습니다.

## Screenshot
<!--기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요  -->

## 💬 리뷰 요구사항(선택)
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
 고민사항도 적어주세요.  -->
